### PR TITLE
chore: use https not ssh for gitmodule to allow downloading on Ares

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ecrs"]
 	path = ecrs
-	url = git@github.com:ecrs-org/ecrs.git
+	url = https://github.com/ecrs-org/ecrs.git


### PR DESCRIPTION
## Description

<!-- Please describe the motivation & changes introduced by this PR -->

## Linked issues

<!-- Please use "Resolves #<issue_no> syntax in case this PR should be linked to an issue -->

## Important implementation details

<!-- if any, optional section -->
