### PR TITLE
refact: lazy load command dependent modules & split command implementations

### DIFF
--- a/ecdk/src/cli/__init__.py
+++ b/ecdk/src/cli/__init__.py
@@ -2,5 +2,5 @@ from .cli import (
     parse_cli_args,
 )
 from .args import (
-    Args, RunCmdArgs, PerfcmpCmdArgs, AnalyzeCmdArgs
+    Args, RunCmdArgs, PerfcmpCmdArgs, AnalyzeCmdArgs, CompareCmdArgs
 )

--- a/ecdk/src/cli/args.py
+++ b/ecdk/src/cli/args.py
@@ -7,7 +7,7 @@ from core.env import EnvContext
 @dataclass
 class Args:
     cmd_name: str
-    handler: Callable[[EnvContext, Args], None]
+    handler: Callable[[EnvContext, 'Args'], None]
 
 
 @dataclass

--- a/ecdk/src/cli/cli.py
+++ b/ecdk/src/cli/cli.py
@@ -1,20 +1,13 @@
 import argparse
-import os
-from .args import Args, RunCmdArgs, AnalyzeCmdArgs, PerfcmpCmdArgs, CompareCmdArgs
+from pathlib import Path
+from .args import Args
 from .command import (
     handle_cmd_run,
     handle_cmd_analyze,
     handle_cmd_perfcmp,
     handle_cmd_compare
 )
-from .validation import (
-    validate_cli_args,
-    validate_base_args,
-    validate_run_cmd_args,
-    validate_analyze_cmd_args,
-    validate_perfcmp_cmd_args,
-    validate_compare_cmd_args,
-)
+from .validation import validate_cli_args
 from core.env import EnvContext
 
 
@@ -68,15 +61,8 @@ def build_cli() -> argparse.ArgumentParser:
     return main_parser
 
 
-def merge_run_args_with_context(args: RunCmdArgs, ctx: EnvContext):
-    pass
-
-
 def parse_cli_args(ctx: EnvContext) -> Args:
     args: Args = build_cli().parse_args()
-
-    if args.cmd_name == 'run':
-        merge_run_args_with_context(args, ctx)
 
     validate_cli_args(args)
     return args

--- a/ecdk/src/cli/command.py
+++ b/ecdk/src/cli/command.py
@@ -1,28 +1,4 @@
 from .args import RunCmdArgs, AnalyzeCmdArgs, PerfcmpCmdArgs, CompareCmdArgs
-from experiment.runner import LocalExperimentBatchRunner, AresExpScheduler, HyperQueueRunner
-from experiment.solver import SolverProxy
-from experiment.model import (
-    ExperimentResult,
-    ExperimentConfig,
-    Experiment
-)
-from data.file_resolver import resolve_all_input_files
-from data.processing import (
-    process_experiment_batch_output,
-    compare_exp_batch_outputs,
-    compare_processed_exps
-)
-from data.tools import (
-    maybe_load_instance_metadata,
-    extract_experiments_from_dir,
-)
-from core.tools import (
-    exp_name_from_input_file,
-    output_dir_for_experiment_with_name,
-    attach_timestamp_to_dir,
-    current_timestamp
-)
-from core.fs import initialize_file_hierarchy, init_processed_data_file_hierarchy
 from core.env import EnvContext
 
 
@@ -44,6 +20,7 @@ def handle_cmd_perfcmp(ctx: EnvContext, args: PerfcmpCmdArgs):
     perfcmp(ctx, args)
 
 
-def handle_cmd_compare(args: CompareCmdArgs):
+def handle_cmd_compare(ctx: EnvContext, args: CompareCmdArgs):
     print(f"CompareCmmand run with args: {args}")
-    compare_processed_exps(args.exp_dirs, args.output_dir)
+    from command.compare import compare
+    compare(ctx, args)

--- a/ecdk/src/cli/command.py
+++ b/ecdk/src/cli/command.py
@@ -23,33 +23,25 @@ from core.tools import (
     current_timestamp
 )
 from core.fs import initialize_file_hierarchy, init_processed_data_file_hierarchy
-from core.env import is_running_on_ares, EnvContext
+from core.env import EnvContext
 
 
 def handle_cmd_run(ctx: EnvContext, args: RunCmdArgs):
     print(f"RunCommand run with args: {args}")
-
     from command.run import run
     run(ctx, args)
 
 
-
-
-
 def handle_cmd_analyze(ctx: EnvContext, args: AnalyzeCmdArgs):
     print(f"AnalyzeCommand run with args: {args}")
-
-    experiment_batch: list[Experiment] = extract_experiments_from_dir(args.dir)
-
-    if args.output_dir is not None:
-        init_processed_data_file_hierarchy(experiment_batch, args.output_dir)
-
-    process_experiment_batch_output(experiment_batch, args.output_dir, args.procs, args.plot)
+    from command.analyze import analyze
+    analyze(ctx, args)
 
 
 def handle_cmd_perfcmp(ctx: EnvContext, args: PerfcmpCmdArgs):
     print(f"PerfcmpCommand run with args: {args}")
-    compare_exp_batch_outputs(args.basepath, args.benchpath)
+    from command.perfcmp import perfcmp
+    perfcmp(ctx, args)
 
 
 def handle_cmd_compare(args: CompareCmdArgs):

--- a/ecdk/src/cli/command.py
+++ b/ecdk/src/cli/command.py
@@ -28,48 +28,12 @@ from core.env import is_running_on_ares, EnvContext
 
 def handle_cmd_run(ctx: EnvContext, args: RunCmdArgs):
     print(f"RunCommand run with args: {args}")
-    metadata_store = maybe_load_instance_metadata(args.metadata_file)
 
-    # Not recursive as we don't want to load Taillard specification
-    input_files = resolve_all_input_files(args.input_files, recursive=False)
-    batch = []
-
-    base_dir = args.output_dir
-    if not ctx.is_ares and args.attach_timestamp:
-        base_dir = attach_timestamp_to_dir(base_dir, current_timestamp())
+    from command.run import run
+    run(ctx, args)
 
 
 
-    for file in input_files:
-        name = exp_name_from_input_file(file)
-        metadata = metadata_store.get(name)
-        if metadata is None:
-            print(f"Missing metadata for {metadata}")
-        out_dir = output_dir_for_experiment_with_name(name, base_dir)
-        batch.append(
-            Experiment(
-                name=name,
-                instance=metadata,  # WARN: This may fail for few experiments
-                config=ExperimentConfig(file,
-                                        out_dir,
-                                        args.config_file,
-                                        args.runs if args.runs else 1),
-                result=None
-            )
-        )
-
-    # Create file hierarchy & dump configuration data
-    initialize_file_hierarchy(batch)
-
-    experiment_configs = [exp.config for exp in batch]
-
-    if args.hq and ctx.is_ares:
-        HyperQueueRunner(SolverProxy(args.bin)).run(experiment_configs)
-    else:
-        LocalExperimentBatchRunner(
-            SolverProxy(args.bin),
-            experiment_configs
-        ).run(process_limit=args.procs)
 
 
 def handle_cmd_analyze(ctx: EnvContext, args: AnalyzeCmdArgs):

--- a/ecdk/src/cli/validation.py
+++ b/ecdk/src/cli/validation.py
@@ -1,10 +1,12 @@
+import os
 from .args import (
     Args,
     RunCmdArgs,
     AnalyzeCmdArgs,
     PerfcmpCmdArgs,
+    CompareCmdArgs
 )
-from core.env import EnvContext
+
 
 def validate_base_args(args: Args):
     assert args.cmd_name in ['run', 'analyze', 'perfcmp', 'compare'], "Unrecognized command name"
@@ -50,6 +52,7 @@ def validate_analyze_cmd_args(args: AnalyzeCmdArgs):
 def validate_perfcmp_cmd_args(args: PerfcmpCmdArgs):
     assert args.basepath.is_dir()
     assert args.benchpath.is_dir()
+
 
 def validate_compare_cmd_args(args: CompareCmdArgs):
     assert len(args.exp_dirs) > 1

--- a/ecdk/src/command/__init__.py
+++ b/ecdk/src/command/__init__.py
@@ -1,0 +1,2 @@
+# We do not want to reexport anything explicitly here, to not trigger premature submodule loading
+

--- a/ecdk/src/command/analyze.py
+++ b/ecdk/src/command/analyze.py
@@ -1,0 +1,15 @@
+from .args import AnalyzeCmdArgs
+from experiment.model import Experiment
+from data.processing import process_experiment_batch_output
+from data.tools import extract_experiments_from_dir
+from core.fs import init_processed_data_file_hierarchy
+from core.env import EnvContext
+
+
+def analyze(ctx: EnvContext, args: AnalyzeCmdArgs):
+    experiment_batch: list[Experiment] = extract_experiments_from_dir(args.dir)
+
+    if args.output_dir is not None:
+        init_processed_data_file_hierarchy(experiment_batch, args.output_dir)
+
+    process_experiment_batch_output(experiment_batch, args.output_dir, args.procs, args.plot)

--- a/ecdk/src/command/compare.py
+++ b/ecdk/src/command/compare.py
@@ -5,3 +5,4 @@ from data.processing import compare_processed_exps
 
 def compare(ctx: EnvContext, args: PerfcmpCmdArgs):
     compare_processed_exps(args.exp_dirs, args.output_dir)
+

--- a/ecdk/src/command/compare.py
+++ b/ecdk/src/command/compare.py
@@ -1,0 +1,7 @@
+from core.env import EnvContext
+from cli.args import PerfcmpCmdArgs
+from data.processing import compare_processed_exps
+
+
+def compare(ctx: EnvContext, args: PerfcmpCmdArgs):
+    compare_processed_exps(args.exp_dirs, args.output_dir)

--- a/ecdk/src/command/perfcmp.py
+++ b/ecdk/src/command/perfcmp.py
@@ -3,5 +3,5 @@ from cli.args import PerfcmpCmdArgs
 from data.processing import compare_exp_batch_outputs
 
 
-def perfcmp(ect: EnvContext, args: PerfcmpCmdArgs):
+def perfcmp(ctx: EnvContext, args: PerfcmpCmdArgs):
     compare_exp_batch_outputs(args.basepath, args.benchpath)

--- a/ecdk/src/command/perfcmp.py
+++ b/ecdk/src/command/perfcmp.py
@@ -1,0 +1,7 @@
+from core.env import EnvContext
+from cli.args import PerfcmpCmdArgs
+from data.processing import compare_exp_batch_outputs
+
+
+def perfcmp(ect: EnvContext, args: PerfcmpCmdArgs):
+    compare_exp_batch_outputs(args.basepath, args.benchpath)

--- a/ecdk/src/command/run.py
+++ b/ecdk/src/command/run.py
@@ -1,0 +1,65 @@
+from core.env import EnvContext
+from cli.args import RunCmdArgs
+
+from experiment.runner import LocalExperimentBatchRunner, HyperQueueRunner
+from experiment.solver import SolverProxy
+from experiment.model import (
+    ExperimentConfig,
+    Experiment
+)
+from data.file_resolver import resolve_all_input_files
+from data.tools import (
+    maybe_load_instance_metadata,
+)
+from core.tools import (
+    exp_name_from_input_file,
+    output_dir_for_experiment_with_name,
+    attach_timestamp_to_dir,
+    current_timestamp
+)
+from core.fs import initialize_file_hierarchy
+
+
+def run(ctx: EnvContext, args: RunCmdArgs):
+    metadata_store = maybe_load_instance_metadata(args.metadata_file)
+
+    # Not recursive as we don't want to load Taillard specification
+    input_files = resolve_all_input_files(args.input_files, recursive=False)
+    batch = []
+
+    base_dir = args.output_dir
+    if not ctx.is_ares and args.attach_timestamp:
+        base_dir = attach_timestamp_to_dir(base_dir, current_timestamp())
+
+    for file in input_files:
+        name = exp_name_from_input_file(file)
+        metadata = metadata_store.get(name)
+        if metadata is None:
+            print(f"Missing metadata for {metadata}")
+        out_dir = output_dir_for_experiment_with_name(name, base_dir)
+        batch.append(
+            Experiment(
+                name=name,
+                instance=metadata,  # WARN: This may fail for few experiments
+                config=ExperimentConfig(file,
+                                        out_dir,
+                                        args.config_file,
+                                        args.runs if args.runs else 1),
+                result=None
+            )
+        )
+
+    # Create file hierarchy & dump configuration data
+    initialize_file_hierarchy(batch)
+
+    experiment_configs = [exp.config for exp in batch]
+    solver = SolverProxy(args.bin)
+
+    if args.hq and ctx.is_ares:
+        HyperQueueRunner(solver).run(experiment_configs)
+    else:
+        LocalExperimentBatchRunner(
+            solver,
+            experiment_configs
+        ).run(process_limit=args.procs)
+

--- a/ecdk/src/main.py
+++ b/ecdk/src/main.py
@@ -32,8 +32,7 @@ def configure_env():
 def main():
     configure_env()
     ctx = EnvContext(strict=True)
-    args = cli.parse_cli_args(ctx)  # TODO: This should be other way around. 
-                                    # Context should be create basing on args and then validated
+    args = cli.parse_cli_args(ctx)  # TODO: This should be other way around. Context should be create basing on args and then validated
     args.handler(ctx, args)
 
 


### PR DESCRIPTION
- Create command module
- Move run command to separate module
- Move analyze & perfcmp commands to separate modules
- Migrate rest of the commands to separate module
- Whitespace

## Description <!-- Please describe the motivation & changes introduced by this PR -->

## Linked issues <!-- Please use "Resolves #<issue_no> syntax in case this PR should be linked to an issue -->

Closes #137

## Important implementation details <!-- if any, optional section -->
