### PR TITLE
fix(ecdk): add sleep to HQ setup script, so that the server has time to boot up

### DIFF
--- a/ecdk/scripts/setup_hyperqueue.sh
+++ b/ecdk/scripts/setup_hyperqueue.sh
@@ -9,6 +9,9 @@ module load hyperqueue/0.17.0
 
 nohup hq server start &
 
+# Let the server start
+sleep 3
+
 # Enable automatic allocation (create queue)
 hq alloc add slurm \
   --time-limit 5h \


### PR DESCRIPTION
## Description <!-- Please describe the motivation & changes introduced by this PR -->

## Linked issues <!-- Please use "Resolves #<issue_no> syntax in case this PR should be linked to an issue -->

## Important implementation details <!-- if any, optional section -->
