### PR TITLE
misc: various refacts, code comments, fixes

### DIFF
--- a/ecdk/src/ecdk/cli/args.py
+++ b/ecdk/src/ecdk/cli/args.py
@@ -26,7 +26,7 @@ class RunCmdArgs(Args):
 
 @dataclass
 class AnalyzeCmdArgs(Args):
-    dir: Path
+    input_dir: Path
     metadata_file: Path
     output_dir: Optional[Path]
     procs: Optional[int]

--- a/ecdk/src/ecdk/cli/validation.py
+++ b/ecdk/src/ecdk/cli/validation.py
@@ -40,7 +40,7 @@ def validate_run_cmd_args(args: RunCmdArgs):
 
 
 def validate_analyze_cmd_args(args: AnalyzeCmdArgs):
-    assert args.dir.is_dir(), f'{args.dir} is not a directory'
+    assert args.input_dir.is_dir(), f'{args.dir} is not a directory'
     if args.procs is not None:
         assert args.procs > 0, f'Number of processes must be > 0. Received {args.procs}'
 

--- a/ecdk/src/ecdk/command/analyze.py
+++ b/ecdk/src/ecdk/command/analyze.py
@@ -1,4 +1,4 @@
-from .args import AnalyzeCmdArgs
+from cli.args import AnalyzeCmdArgs
 from experiment.model import Experiment
 from data.processing import process_experiment_batch_output
 from data.tools import extract_experiments_from_dir
@@ -7,7 +7,7 @@ from context import Context
 
 
 def analyze(ctx: Context, args: AnalyzeCmdArgs):
-    experiment_batch: list[Experiment] = extract_experiments_from_dir(args.dir)
+    experiment_batch: list[Experiment] = extract_experiments_from_dir(args.input_dir)
 
     if args.output_dir is not None:
         init_processed_data_file_hierarchy(experiment_batch, args.output_dir)

--- a/ecdk/src/ecdk/command/run.py
+++ b/ecdk/src/ecdk/command/run.py
@@ -57,7 +57,7 @@ def run(ctx: Context, args: RunCmdArgs):
     experiment_configs = [exp.config for exp in batch.experiments]
 
     if args.hq and ctx.is_ares:
-        HyperQueueRunner(SolverProxy(args.bin)).run(batch, context=ctx, postprocess=args.experimental_postprocess)
+        HyperQueueRunner(SolverProxy(args.bin)).run(batch, ctx=ctx, postprocess=args.experimental_postprocess)
     else:
         LocalExperimentBatchRunner(
             SolverProxy(args.bin),

--- a/ecdk/src/ecdk/command/run.py
+++ b/ecdk/src/ecdk/command/run.py
@@ -54,7 +54,7 @@ def run(ctx: Context, args: RunCmdArgs):
     # Create file hierarchy & dump configuration data
     initialize_file_hierarchy(batch)
 
-    experiment_configs = [exp.config for exp in batch]
+    experiment_configs = [exp.config for exp in batch.experiments]
 
     if args.hq and ctx.is_ares:
         HyperQueueRunner(SolverProxy(args.bin)).run(batch, context=ctx, postprocess=args.experimental_postprocess)

--- a/ecdk/src/ecdk/command/run.py
+++ b/ecdk/src/ecdk/command/run.py
@@ -5,7 +5,8 @@ from experiment.model import (
     ExperimentResult,
     ExperimentConfig,
     Experiment,
-    ExperimentBatch
+    ExperimentBatch,
+    SolverConfigFile
 )
 from data.file_resolver import resolve_all_input_files
 from data.tools import maybe_load_instance_metadata
@@ -49,7 +50,8 @@ def run(ctx: Context, args: RunCmdArgs):
             )
         )
 
-    batch = ExperimentBatch(output_dir=base_dir, experiments=batch)
+    solver_config = SolverConfigFile(args.config_file) if args.config_file else None
+    batch = ExperimentBatch(output_dir=base_dir, experiments=batch, solver_config=solver_config)
 
     # Create file hierarchy & dump configuration data
     initialize_file_hierarchy(batch)

--- a/ecdk/src/ecdk/command/run.py
+++ b/ecdk/src/ecdk/command/run.py
@@ -54,7 +54,7 @@ def run(ctx: Context, args: RunCmdArgs):
     experiment_configs = [exp.config for exp in batch]
 
     if args.hq and ctx.is_ares:
-        HyperQueueRunner(SolverProxy(args.bin)).run(experiment_configs, postprocess=args.experimental_postprocess)
+        HyperQueueRunner(SolverProxy(args.bin)).run(experiment_configs, context=ctx, postprocess=args.experimental_postprocess)
     else:
         LocalExperimentBatchRunner(
             SolverProxy(args.bin),

--- a/ecdk/src/ecdk/command/run.py
+++ b/ecdk/src/ecdk/command/run.py
@@ -4,7 +4,8 @@ from experiment.solver import SolverProxy
 from experiment.model import (
     ExperimentResult,
     ExperimentConfig,
-    Experiment
+    Experiment,
+    ExperimentBatch
 )
 from data.file_resolver import resolve_all_input_files
 from data.tools import maybe_load_instance_metadata
@@ -48,13 +49,15 @@ def run(ctx: Context, args: RunCmdArgs):
             )
         )
 
+    batch = ExperimentBatch(output_dir=base_dir, experiments=batch)
+
     # Create file hierarchy & dump configuration data
     initialize_file_hierarchy(batch)
 
     experiment_configs = [exp.config for exp in batch]
 
     if args.hq and ctx.is_ares:
-        HyperQueueRunner(SolverProxy(args.bin)).run(experiment_configs, context=ctx, postprocess=args.experimental_postprocess)
+        HyperQueueRunner(SolverProxy(args.bin)).run(batch, context=ctx, postprocess=args.experimental_postprocess)
     else:
         LocalExperimentBatchRunner(
             SolverProxy(args.bin),

--- a/ecdk/src/ecdk/core/fs.py
+++ b/ecdk/src/ecdk/core/fs.py
@@ -25,9 +25,7 @@ def solver_logfile_for_series(base_output_dir: Path, series_id: int) -> Path:
 
 # TODO: This function should not be here
 def dump_exp_batch_config(config_file: Path, batch: ExperimentBatch):
-    joined_config = {
-        "configs": list(map(lambda e: e.as_dict(), batch.experiments))
-    }
+    joined_config = batch.as_dict()
 
     with open(config_file, 'w') as file:
         json.dump(joined_config, file, indent=4)

--- a/ecdk/src/ecdk/core/fs.py
+++ b/ecdk/src/ecdk/core/fs.py
@@ -24,9 +24,9 @@ def solver_logfile_for_series(base_output_dir: Path, series_id: int) -> Path:
 
 
 # TODO: This function should not be here
-def dump_exp_batch_config(config_file: Path, experiments: list[Experiment]):
+def dump_exp_batch_config(config_file: Path, batch: ExperimentBatch):
     joined_config = {
-        "configs": list(map(lambda e: e.as_dict(), experiments))
+        "configs": list(map(lambda e: e.as_dict(), batch.experiments))
     }
 
     with open(config_file, 'w') as file:
@@ -46,7 +46,7 @@ def initialize_file_hierarchy(batch: ExperimentBatch):
     base_dir.mkdir(parents=True, exist_ok=True)
     config_file = base_dir.joinpath("config.json")
 
-    dump_exp_batch_config(config_file, experiments)
+    dump_exp_batch_config(config_file, batch)
 
     for experiment in experiments:
         experiment.config.output_dir.mkdir(parents=True, exist_ok=True)
@@ -85,12 +85,4 @@ def init_processed_data_file_hierarchy(exps: list[Experiment], basedir: Path):
         # We do not need tabledir per experiment right now
         # Uncomment it once there is some per-experiment anaylisis done
         # get_tabledir_for_exp(exp, basedir).mkdir(parents=True, exist_ok=True)
-
-
-
-
-
-
-
-
 

--- a/ecdk/src/ecdk/core/fs.py
+++ b/ecdk/src/ecdk/core/fs.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from experiment.model import Experiment
+from experiment.model import Experiment, ExperimentBatch
 
 
 def experiment_file_from_directory(directory: Path) -> Path:
@@ -34,13 +34,15 @@ def dump_exp_batch_config(config_file: Path, experiments: list[Experiment]):
 
 
 # TODO: This function should not be here
-def initialize_file_hierarchy(experiments: list[Experiment]):
+def initialize_file_hierarchy(batch: ExperimentBatch):
     """ Creates directory structure for the output & dumps experiments / series configuration
     to appriopriate directories """
 
+    experiments = batch.experiments
+
     assert len(experiments) > 0, "No experiments were specified"
 
-    base_dir = experiments[0].config.output_dir.parent
+    base_dir = batch.output_dir
     base_dir.mkdir(parents=True, exist_ok=True)
     config_file = base_dir.joinpath("config.json")
 

--- a/ecdk/src/ecdk/core/util.py
+++ b/ecdk/src/ecdk/core/util.py
@@ -2,6 +2,7 @@ from typing import Iterable, Optional, TypeVar, Callable
 import itertools as it
 
 T = TypeVar('T')
+U = TypeVar('U')
 
 
 def find_first_or_none(iterable: Iterable[T], pred: Callable[[T], bool]) -> Optional[T]:
@@ -17,4 +18,10 @@ def iter_batched(iterable: Iterable, n: int):
     iterator = iter(iterable)
     while batch := tuple(it.islice(iterator, n)):
         yield batch
+
+
+def nonesafe_map(obj: Optional[T], mapping: Callable[[T], U]) -> Optional[U]:
+    if obj is None:
+        return None
+    return mapping(obj)
 

--- a/ecdk/src/ecdk/data/model.py
+++ b/ecdk/src/ecdk/data/model.py
@@ -159,6 +159,8 @@ def config_for_event(event: EventName) -> EventConfig:
 
 @dataclass
 class JoinedExperimentData:
+    """ Joined data from all series of given experiment. """
+
     newbest: DataFrame
     popmetrics: DataFrame
     bestingen: DataFrame

--- a/ecdk/src/ecdk/data/processing.py
+++ b/ecdk/src/ecdk/data/processing.py
@@ -94,8 +94,6 @@ def compare_processed_exps(exp_dirs: list[Path], outdir: Optional[Path]):
 
         numeric_cols = exp_conv_df_1.select(cs.numeric()).columns
 
-        # joined_df = exp_conv_df_1.vstack(exp_conv_df_2)
-
         joined_df = exp_conv_df_1.join(exp_conv_df_2, on='expname')
         stat_df = (joined_df.lazy()
             .select([

--- a/ecdk/src/ecdk/data/processing.py
+++ b/ecdk/src/ecdk/data/processing.py
@@ -52,14 +52,14 @@ def process_experiment_batch_output(batch: list[Experiment], outdir: Optional[Pa
 
     data: list[JoinedExperimentData] = [experiment_data_from_all_series(exp) for exp in batch]
 
-    # if process_count == 1:
-    #     for exp, expdata in zip(batch, data):
-    #         process_experiment_data(exp, expdata, outdir, should_plot)
-    # else:
-    #     from multiprocessing import get_context
-    #     with get_context("spawn").Pool(process_count) as pool:
-    #         pool.starmap(process_experiment_data, zip(batch, data, it.repeat(outdir), it.repeat(should_plot)))
-    #
+    if process_count == 1:
+        for exp, expdata in zip(batch, data):
+            process_experiment_data(exp, expdata, outdir, should_plot)
+    else:
+        from multiprocessing import get_context
+        with get_context("spawn").Pool(process_count) as pool:
+            pool.starmap(process_experiment_data, zip(batch, data, it.repeat(outdir), it.repeat(should_plot)))
+
     tabledir = get_main_tabledir(outdir) if outdir is not None else None
     global_df = compute_global_exp_stats(batch, data, tabledir)
     conv_df = compute_convergence_iteration_per_exp(batch, data, tabledir)

--- a/ecdk/src/ecdk/experiment/model.py
+++ b/ecdk/src/ecdk/experiment/model.py
@@ -180,3 +180,14 @@ class Experiment:
                    instance=exp_dict["instance"],
                    config=exp_dict["config"])
 
+
+@dataclass
+class ExperimentBatch:
+    """  """
+
+    # Output directory of whole experiment batch (list of experiments)
+    output_dir: Path
+
+    # List of experiments to conduct
+    experiments: list[Experiment]
+

--- a/ecdk/src/ecdk/experiment/model.py
+++ b/ecdk/src/ecdk/experiment/model.py
@@ -8,9 +8,19 @@ import datetime as dt
 
 @dataclass(frozen=True)
 class SeriesOutputFiles:
+    """ Describes structure of output directory for given **series** of given experiment """
+
+    # Path to the series output directory
     directory: Path
+
+    # Mapping of csv event files (see docs on model for format explanation). EventName -> Path
     event_files: Dict[str, Path]
+
+    # Path to the summary of solver output. This file is in JSON format & contains
+    # information defined by the `SeriesOutputMetadata` type
     run_metadata_file: Path
+
+    # Stdout file of solver process for given series. Logs, errors, warnings of the solver
     logfile: Optional[Path]
 
 
@@ -69,9 +79,14 @@ class SolverResult:
 @dataclass(frozen=True)
 class ExperimentConfig:
     """ Experiment is a series of solver runs over single test case """
+
+    # Path to file with JSSP instance specification
     input_file: Path
+    # Path to directory, where subdirectories for given series outputs will be created
     output_dir: Path
+    # Optional path to solver config file, this should be passed throught directly to solver
     config_file: Optional[Path]
+    # Number of repetitions to run for this experiment
     n_series: int
 
     def as_dict(self) -> dict:

--- a/ecdk/src/ecdk/experiment/model.py
+++ b/ecdk/src/ecdk/experiment/model.py
@@ -127,7 +127,7 @@ class ExperimentConfig:
             input_file=Path(d['input_file']),
             output_dir=Path(d['output_dir']),
             config_file=Path(d.get('config_file')),
-            n_series=d['n_series'],
+            n_series=int(d['n_series']),
         )
 
 

--- a/ecdk/src/ecdk/experiment/model.py
+++ b/ecdk/src/ecdk/experiment/model.py
@@ -126,20 +126,13 @@ class SolverConfigFileContents:
 
     @classmethod
     def from_dict(cls, d: Dict):
-        input_file = d.get("input_file")
-        output_dir = d.get("output_dir")
-        n_gen = d.get("n_gen")
-        pop_size = d.get("pop_size")
-        delay_const_factor = d.get("delay_const_factor")
-        solver_type = d.get("solver_type")
-
         return SolverConfigFileContents(
-            input_file=core.util.nonesafe_map(input_file, Path),
-            output_dir=core.util.nonesafe_map(output_dir, Path),
-            n_gen=core.util.nonesafe_map(n_gen, int),
-            pop_size=core.util.nonesafe_map(pop_size, int),
-            delay_const_factor=core.util.nonesafe_map(delay_const_factor, float),
-            solver_type=solver_type or "default"
+            input_file=core.util.nonesafe_map(d.get("input_file"), Path),
+            output_dir=core.util.nonesafe_map(d.get("output_dir"), Path),
+            n_gen=core.util.nonesafe_map(d.get("n_gen"), int),
+            pop_size=core.util.nonesafe_map(d.get("pop_size"), int),
+            delay_const_factor=core.util.nonesafe_map(d.get("delay_const_factor"), float),
+            solver_type=d.get("solver_type") or "default"
         )
 
     def as_dict(self):

--- a/ecdk/src/ecdk/experiment/runner.py
+++ b/ecdk/src/ecdk/experiment/runner.py
@@ -72,6 +72,8 @@ class LocalExperimentRunner:
         # Actual scheduling
         poll_interval: float = 0.1
         tasks = list(map(lambda x: self._task_from_params(x[0], x[1]), enumerate(params_iter)))
+
+        # Delegate running to scheduler
         completed_tasks, runinfo = MultiProcessTaskRunner().run(tasks, process_limit, poll_interval)
 
         # Result collection
@@ -120,7 +122,7 @@ class HyperQueueRunner:
         self._solver: SolverProxy = solver
         self._client = hq.Client()  # We try to create client from default options, not passing path to server files rn
 
-    def run(self, configs: list[ExperimentConfig], postprocess: bool = False) -> None:
+    def run(self, configs: list[ExperimentConfig], ctx: Context, postprocess: bool = False) -> None:
         import hyperqueue as hq
         # Important thing here is that we only dispatch the jobs, without waiting for their completion, at for least now
         params_iter = solver_params_from_exp_config_collection(configs)
@@ -155,4 +157,6 @@ class HyperQueueRunner:
         #
         # Maybe it would actually make more sense to create separate postprocess command from it
         # and just run it after completing computations? This looks like more than few lines of code.
+
+        # job.program(['zip', '-q', '-r', ])
 

--- a/ecdk/src/ecdk/experiment/solver.py
+++ b/ecdk/src/ecdk/experiment/solver.py
@@ -1,6 +1,5 @@
 import subprocess as sp
 import datetime as dt
-from typing import Iterable
 from pathlib import Path
 from .model import (
     SolverParams,
@@ -8,7 +7,6 @@ from .model import (
     SolverRunMetadata,
 )
 from core.series import load_series_output
-from core.scheduler import Task, MultiProcessTaskRunner
 
 
 class SolverProxy:

--- a/ecdk/src/ecdk/experiment/solver.py
+++ b/ecdk/src/ecdk/experiment/solver.py
@@ -19,12 +19,12 @@ class SolverProxy:
     def __init__(self, binary: Path):
         self.binary: Path = binary
 
-    def __task_from_params(self, id: int, params: SolverParams) -> Task:
-        return Task(
-            id=id,
-            process_args=self.exec_cmd_from_params(params),
-            stdout_file=params.stdout_file
-        )
+    # def __task_from_params(self, id: int, params: SolverParams) -> Task:
+    #     return Task(
+    #         id=id,
+    #         process_args=self.exec_cmd_from_params(params),
+    #         stdout_file=params.stdout_file
+    #     )
 
     def exec_cmd_from_params(self, params: SolverParams, stringify_args: bool = False) -> list[str]:
         base = [
@@ -62,15 +62,15 @@ class SolverProxy:
             series_output=load_series_output(params.output_dir, lazy=True),
             run_metadata=SolverRunMetadata(duration=timedelta, status=completed_process.returncode))
 
-    def run_multiprocess(self, params: Iterable[SolverParams], process_limit: int = 1, poll_interval: float = 0.1) -> list[SolverResult]:
-        tasks = list(map(lambda x: self.__task_from_params(x[0], x[1]), enumerate(params)))
-        completed_tasks, runinfo = MultiProcessTaskRunner().run(tasks, process_limit, poll_interval)
-
-        return [SolverResult(
-            series_output=load_series_output(param.output_dir, lazy=True),
-            run_metadata=SolverRunMetadata(  # Propagate more information from completed taks here
-                duration=compl_task.duration,
-                status=compl_task.return_code
-            )
-        ) for param, compl_task in zip(params, completed_tasks)]
+    # def run_multiprocess(self, params: Iterable[SolverParams], process_limit: int = 1, poll_interval: float = 0.1) -> list[SolverResult]:
+    #     tasks = list(map(lambda x: self.__task_from_params(x[0], x[1]), enumerate(params)))
+    #     completed_tasks, runinfo = MultiProcessTaskRunner().run(tasks, process_limit, poll_interval)
+    #
+    #     return [SolverResult(
+    #         series_output=load_series_output(param.output_dir, lazy=True),
+    #         run_metadata=SolverRunMetadata(  # Propagate more information from completed taks here
+    #             duration=compl_task.duration,
+    #             status=compl_task.return_code
+    #         )
+    #     ) for param, compl_task in zip(params, completed_tasks)]
 

--- a/solver/src/config.rs
+++ b/solver/src/config.rs
@@ -29,7 +29,7 @@ pub struct Config {
     /// Delay = Gene_{n+g} * delay_const_factor * maxdur. If not specified, defaults to 1.5.
     pub delay_const_factor: Option<f64>,
 
-    /// Solver type to run. Available options: `default`, `randomsearch`, `custom_crossover`
+    /// Solver type to run. Available options: `default`, `randomsearch`, `midpoint`, `double_singlepoint`.
     pub solver_type: String,
 }
 

--- a/solver/src/config.rs
+++ b/solver/src/config.rs
@@ -4,10 +4,10 @@ use serde::Deserialize;
 
 use crate::cli::Args;
 
-pub const SOLVER_TYPE_DEFAULT: &'static str = "default";
-pub const SOLVER_TYPE_RANDOMSEARCH: &'static str = "randomsearch";
-pub const SOLVER_TYPE_MIDPOINT: &'static str = "midpoint";
-pub const SOLVER_TYPE_DOUBLED_CROSSOVER: &'static str = "double_singlepoint";
+pub const SOLVER_TYPE_DEFAULT: &str = "default";
+pub const SOLVER_TYPE_RANDOMSEARCH: &str = "randomsearch";
+pub const SOLVER_TYPE_MIDPOINT: &str = "midpoint";
+pub const SOLVER_TYPE_DOUBLED_CROSSOVER: &str = "double_singlepoint";
 
 #[derive(Debug, Clone)]
 pub struct Config {

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -42,10 +42,8 @@ fn run() {
     register_solvers(&mut solver_registry);
 
     let run_config = get_run_config(&instance, &config);
-    let solver = solver_registry.get(&config.solver_type).expect(&format!(
-        "Failed to find solver of type {} in registry",
-        &config.solver_type
-    ));
+    let solver = solver_registry.get(&config.solver_type).unwrap_or_else(|| panic!("Failed to find solver of type {} in registry",
+        &config.solver_type));
     solver.run(instance, run_config);
 }
 

--- a/solver/src/parse.rs
+++ b/solver/src/parse.rs
@@ -1,29 +1,20 @@
-use core::fmt;
 use std::{
     io::{BufReader, Read},
     path::PathBuf,
 };
 
 use itertools::Itertools;
+use thiserror::Error;
 
 use crate::problem::{JsspConfig, JsspInstance, JsspInstanceMetadata, Operation};
 
 pub type Result<T> = std::result::Result<T, JsspInstanceLoadingError>;
 pub type Error = JsspInstanceLoadingError;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Error)]
 pub enum JsspInstanceLoadingError {
+    #[error("File does not exist: {0}")]
     FileDoesNotExist(String),
-    // ParseError(String),
-}
-
-impl fmt::Display for JsspInstanceLoadingError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::FileDoesNotExist(file) => write!(f, "File does not exist: {file}"),
-            // Self::ParseError(err) => write!(f, "Parsing error: {err}"),
-        }
-    }
 }
 
 impl TryFrom<&PathBuf> for JsspInstance {
@@ -32,6 +23,7 @@ impl TryFrom<&PathBuf> for JsspInstance {
     fn try_from(path: &PathBuf) -> Result<Self> {
         let name = path.file_stem().unwrap().to_str().unwrap();
 
+        // TODO: Handle other types of errors here and do not lie to the user in general...
         let Ok(file) = std::fs::OpenOptions::new().read(true).open(path) else {
             return Err(Error::FileDoesNotExist(path.to_str().unwrap().to_owned()));
         };

--- a/solver/src/parse.rs
+++ b/solver/src/parse.rs
@@ -40,7 +40,7 @@ impl TryFrom<&PathBuf> for JsspInstance {
             .split_whitespace()
             .map(|n_str| n_str.parse::<usize>().unwrap())
             .collect_vec();
-        assert!(first_line.len() == 2);
+        assert!(first_line.len() == 2, "The first line should be composed of two, space separated numbers");
 
         let mut jobs: Vec<Vec<Operation>> = Vec::new();
         let mut op_id: usize = 0;

--- a/solver/src/problem/crossover.rs
+++ b/solver/src/problem/crossover.rs
@@ -168,7 +168,7 @@ impl CrossoverOperator<JsspIndividual> for DoubledCrossover {
 
 #[cfg(test)]
 mod test {
-    use ecrs::ga::{operators::crossover::CrossoverOperator, Individual};
+    use ecrs::ga::{operators::crossover::CrossoverOperator};
     use itertools::Itertools;
 
     use crate::problem::{

--- a/solver/src/problem/individual.rs
+++ b/solver/src/problem/individual.rs
@@ -51,7 +51,7 @@ impl PartialEq for JsspIndividual {
 impl Eq for JsspIndividual {}
 
 impl PartialOrd for JsspIndividual {
-    #[allow(clippy::incorrect_partial_ord_impl_on_ord_type)]
+    #[allow(clippy::non_canonical_partial_ord_impl)]
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         self.fitness.partial_cmp(&other.fitness)
     }


### PR DESCRIPTION
- Add comments on how to reorganise runners
- Start adding comments to experiment model structures, so that I don't have to lookup their usage to understand what do they do everytime I back doing this project
- Add comments to the rest of model types in experiment.model module
- Move actual process scheduling from SolverProxy to local runner, tmp
- Pass context to HQ runner
- Add possibility to postprocess
- Fix
- Another fix
- Cargo clippy --fix
- Use thiserror instead of manual error type implementation
- Add some error messages
- Fix conversion of ExperimentConfig
- Fix another previously undetected merge artifact
- A bit of cleanup
- Load & save config used for running experiment batch, so that it is easier to identify which solver was being run
- A bit of cleanup
- Some comment

## Description <!-- Please describe the motivation & changes introduced by this PR -->

## Linked issues <!-- Please use "Resolves #<issue_no> syntax in case this PR should be linked to an issue -->

## Important implementation details <!-- if any, optional section -->
