### PR TITLE
fix: incorrect machine edges set during schedule decoding & some miscs

### DIFF
--- a/ecdk/.envrc
+++ b/ecdk/.envrc
@@ -14,6 +14,7 @@ export MY_PARTITION="plgrid"
 export MY_GRANT_LSC="plglscclass23"
 export MY_GRANT_MASTER="plgjobshop"
 
-export MY_GRANT=${MY_GRANT_MASTER}
+# Use LSC as long as possible
+export MY_GRANT=${MY_GRANT_LSC}
 export MY_GRANT_RES_CPU="${MY_GRANT}-cpu"
 

--- a/ecdk/.envrc
+++ b/ecdk/.envrc
@@ -9,5 +9,11 @@ else
   source_env_if_exists ./.envrc.dev
 fi
 
+export MY_PARTITION="plgrid"
 
+export MY_GRANT_LSC="plglscclass23"
+export MY_GRANT_MASTER="plgjobshop"
+
+export MY_GRANT=${MY_GRANT_MASTER}
+export MY_GRANT_RES_CPU="${MY_GRANT}-cpu"
 

--- a/ecdk/.envrc.ares
+++ b/ecdk/.envrc.ares
@@ -1,3 +1,5 @@
+echo "Sourcing ARES env file"
+
 export MY_MASTER_REPO="$MY_MASTER_REPO"
 export MY_SCRATCH="$SCRATCH"
 export MY_GROUPS_STORAGE="$MY_GROUPS_STORAGE"
@@ -12,4 +14,5 @@ export MY_INSTANCES_DIR="$MY_ECDK/data/instances"
 
 # 0 means true!
 export MY_IS_ARES=0
+
 

--- a/ecdk/.envrc.dev
+++ b/ecdk/.envrc.dev
@@ -1,3 +1,5 @@
+echo "Sourcing DEV env file"
+
 export MY_MASTER_REPO=$(pwd)/../
 export MY_SCRATCH="$MY_MASTER_REPO/raw-data-archive"
 export MY_GROUPS_STORAGE="$MY_MASTER_REPO/ecdk/raw.out"

--- a/ecdk/scripts/setup_hyperqueue.sh
+++ b/ecdk/scripts/setup_hyperqueue.sh
@@ -13,8 +13,6 @@ assert_envvar_set MY_PARTITION
 assert_envvar_set MY_GRANT
 assert_envvar_set MY_GRANT_RES_CPU
 
-exit 0
-
 module load python/3.10.8-gcccore-12.2.0
 pip install -r requirements.txt
 
@@ -29,7 +27,7 @@ sleep 5
 
 # Enable automatic allocation (create queue)
 hq alloc add slurm \
-  --time-limit 5h \
+  --time-limit 14h \
   --workers-per-alloc 1 \
   --max-worker-count 48 \
   --backlog 36 \

--- a/ecdk/scripts/setup_hyperqueue.sh
+++ b/ecdk/scripts/setup_hyperqueue.sh
@@ -27,7 +27,7 @@ sleep 5
 
 # Enable automatic allocation (create queue)
 hq alloc add slurm \
-  --time-limit 14h \
+  --time-limit 6h \
   --workers-per-alloc 1 \
   --max-worker-count 48 \
   --backlog 36 \

--- a/ecdk/scripts/setup_hyperqueue.sh
+++ b/ecdk/scripts/setup_hyperqueue.sh
@@ -1,4 +1,19 @@
+# !/bin/bash
 #!/usr/bin/bash
+
+function assert_envvar_set() {
+  cmdname=$1
+  if [ -z "${!cmdname}" ]; then
+      echo "$cmdname is unset or set to the empty string"
+      exit 1
+  fi
+}
+
+assert_envvar_set MY_PARTITION
+assert_envvar_set MY_GRANT
+assert_envvar_set MY_GRANT_RES_CPU
+
+exit 0
 
 module load python/3.10.8-gcccore-12.2.0
 pip install -r requirements.txt
@@ -10,7 +25,7 @@ module load hyperqueue/0.17.0
 nohup hq server start &
 
 # Let the server start
-sleep 3
+sleep 5
 
 # Enable automatic allocation (create queue)
 hq alloc add slurm \
@@ -20,10 +35,7 @@ hq alloc add slurm \
   --backlog 36 \
   --idle-timeout 1m \
   -- \
-  --partition=plgrid \
-  --account=plglscclass23-cpu \
-  --mem-per-cpu=256M \
-  --mail-type=begin \
-  --mail-type=end \
-  --mail-user=kkafara@student.agh.edu.pl
+  --partition=${MY_PARTITION} \
+  --account=${MY_GRANT_RES_CPU} \
+  --mem-per-cpu=256M
 

--- a/ecdk/src/ecdk/main.py
+++ b/ecdk/src/ecdk/main.py
@@ -6,9 +6,6 @@
 #SBATCH --account=plglscclass23-cpu
 #SBATCH --cpus-per-task=36
 #SBATCH --mem-per-cpu=512M
-#SBATCH --mail-type=begin
-#SBATCH --mail-type=end
-#SBATCH --mail-user=kkafara@student.agh.edu.pl
 
 import sys
 from pathlib import Path

--- a/ecdk/tests/test_core_fs.py
+++ b/ecdk/tests/test_core_fs.py
@@ -1,6 +1,6 @@
 from typing import Optional
 from pathlib import Path
-from experiment.model import Experiment, ExperimentConfig
+from experiment.model import Experiment, ExperimentConfig, ExperimentBatch
 from data.model import InstanceMetadata
 from core.fs import (
     get_main_plotdir,
@@ -96,7 +96,8 @@ def test_run_file_hierarchy_creation(tmp_path):
     exp_1 = create_mock_exp('test01', output_dir=exp_1_dir, n_series=n_series)
     exp_2 = create_mock_exp('test02', output_dir=exp_2_dir, n_series=n_series)
 
-    initialize_file_hierarchy([exp_1, exp_2])
+    batch = ExperimentBatch(output_dir=tmp_path, experiments=[exp_1, exp_2], solver_config=None)
+    initialize_file_hierarchy(batch)
 
     assert exp_1_dir.is_dir()
     assert exp_2_dir.is_dir()

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -21,7 +21,7 @@ fn register_solvers(registry: &mut SolverRegistry) {
     registry.insert(Box::new(RandomSearch));
 }
 
-fn run() {
+fn run() -> anyhow::Result<()> {
     let args = cli::parse_args();
     let config = match Config::try_from(args) {
         Ok(config) => config,
@@ -44,10 +44,9 @@ fn run() {
     let run_config = get_run_config(&instance, &config);
     let solver = solver_registry.get(&config.solver_type).unwrap_or_else(|| panic!("Failed to find solver of type {} in registry",
         &config.solver_type));
-    solver.run(instance, run_config);
+    solver.run(instance, run_config)
 }
 
-fn main() -> Result<(), ()> {
-    run();
-    Ok(())
+fn main() -> anyhow::Result<()> {
+    run()
 }

--- a/solver/src/problem.rs
+++ b/solver/src/problem.rs
@@ -164,8 +164,8 @@ pub struct Machine {
     /// Remaining machine capacity. If a range is added -> this means that the machine is occupied in that range
     // For "possibly better implementation"
     rmc: Vec<MachineAllocation>,
-    pub last_scheduled_op: Option<usize>,
-    pub last_scheduled_range: Option<Range<usize>>,
+    // pub last_scheduled_op: Option<usize>,
+    // pub last_scheduled_range: Option<Range<usize>>,
 }
 
 impl Machine {
@@ -174,8 +174,8 @@ impl Machine {
             id,
             // rmc: vec![1; rmc_capacity],
             rmc: Vec::new(),
-            last_scheduled_op: None,
-            last_scheduled_range: None,
+            // last_scheduled_op: None,
+            // last_scheduled_range: None,
         }
     }
 }
@@ -205,11 +205,11 @@ impl Machine {
     /// you want to reserve.
     ///
     pub fn reserve(&mut self, range: Range<usize>, op: usize) -> MachineNeighs {
-        if let Some(ref last_scheduled_range) = self.last_scheduled_range {
-            if range.end <= last_scheduled_range.start {
-                warn!("Scheduling operation {} on machine {} at {:?} BEFORE already scheduled operation {} at {:?}", op, self.id, &range, self.last_scheduled_op.unwrap(), last_scheduled_range);
-            }
-        }
+        // if let Some(ref last_scheduled_range) = self.last_scheduled_range {
+        //     if range.end <= last_scheduled_range.start {
+        //         warn!("Scheduling operation {} on machine {} at {:?} BEFORE already scheduled operation {} at {:?}", op, self.id, &range, self.last_scheduled_op.unwrap(), last_scheduled_range);
+        //     }
+        // }
 
         self.rmc.push(MachineAllocation::new(op, range.clone()));
 
@@ -225,8 +225,8 @@ impl Machine {
             .filter(|alloc| alloc.range.start >= range.end)
             .min_by_key(|alloc| alloc.range.start);
 
-        self.last_scheduled_op = Some(op);
-        self.last_scheduled_range = Some(range);
+        // self.last_scheduled_op = Some(op);
+        // self.last_scheduled_range = Some(range);
 
         MachineNeighs::new(
             lower_bound.map(|alloc| alloc.op_id),
@@ -237,8 +237,8 @@ impl Machine {
     /// Removes all ranges from the machine state allowing instance of this type to be reused
     pub fn reset(&mut self) {
         self.rmc.clear();
-        self.last_scheduled_op = None;
-        self.last_scheduled_range = None;
+        // self.last_scheduled_op = None;
+        // self.last_scheduled_range = None;
     }
 }
 

--- a/solver/src/problem/fitness.rs
+++ b/solver/src/problem/fitness.rs
@@ -51,10 +51,9 @@ impl JsspFitness {
         // Iteration number. Notation borrowed from the paper.
         let mut g = 1;
 
-        // Scheduling time associated with current iteration g. This is usually equal to largest
-        // schedule time form g-1 iteration + 1, so that if we do not have any operations feasible
-        // to schedule with current time restriction (see the definition of delay_feasibles) we
-        // relax the condition.
+        // Scheduling time associated with current iteration g.
+        // This is equal precisely to smallest finish time of already scheduled operation,
+        // s.t. it is greater than current value of t_g.
         let mut t_g = 0;
 
         // Longest duration of a single opration

--- a/solver/src/problem/fitness.rs
+++ b/solver/src/problem/fitness.rs
@@ -131,6 +131,11 @@ impl JsspFitness {
         }
         let makespan = usize::min(last_finish_time, self.local_search(indv));
 
+        // After local search finish times of particual operations might not be accurate, due to
+        // changes in graph structure (machine precedences) and lack of updates of finish times
+        // alongside. But the graph structure is correct -> it should be possible to reconstruct
+        // the exact schedule, not only the makespan.
+
         indv.fitness = makespan;
         indv.is_fitness_valid = true;
         indv.is_dirty = true;
@@ -326,7 +331,7 @@ impl JsspFitness {
             crt_op = &indv.operations[edge.neigh_id];
         }
         // there should be empty block at the end
-        debug_assert!(blocks.last().unwrap().is_empty());
+        assert!(blocks.last().unwrap().is_empty());
         blocks.pop();
     }
 
@@ -335,6 +340,7 @@ impl JsspFitness {
         indv.operations[0].critical_distance
     }
 
+    /// Please note that `first_op_id` op MUST actually be before `sec_op_id` op in the block!
     fn swap_ops(&mut self, indv: &mut JsspIndividual, first_op_id: usize, sec_op_id: usize) {
         // We assume few things here:
         debug_assert!(first_op_id != 0 && sec_op_id != 0);

--- a/solver/src/problem/fitness.rs
+++ b/solver/src/problem/fitness.rs
@@ -117,7 +117,32 @@ impl JsspFitness {
                     indv.operations[j].machine_pred = Some(last_sch_op);
                 }
 
-                indv.machines[op_j_machine].reserve(finish_time_j - op_j_duration..finish_time_j, j);
+                let neighs = indv.machines[op_j_machine].reserve(finish_time_j - op_j_duration..finish_time_j, j);
+
+                if neighs.pred.is_some() && neighs.succ.is_some() {
+                    let pred_id = unsafe { neighs.pred.unwrap_unchecked() };
+                    let succ_id = unsafe { neighs.succ.unwrap_unchecked() };
+
+                    let machine_pred = &mut indv.operations[pred_id];
+                    assert!(machine_pred.edges_out.len() == 2);
+                    machine_pred.edges_out.pop();
+                    machine_pred.edges_out.push(Edge::new(j, EdgeKind::MachineSucc));
+
+                    indv.operations[j].machine_pred = Some(pred_id);
+                    indv.operations[j].edges_out.push(Edge::new(succ_id, EdgeKind::MachineSucc));
+
+                    indv.operations[succ_id].machine_pred = Some(j);
+                } else if neighs.pred.is_some() {
+                    let pred_id = unsafe { neighs.pred.unwrap_unchecked() };
+                    let machine_pred = &mut indv.operations[pred_id];
+                    assert!(machine_pred.edges_out.len() == 1);
+                    machine_pred.edges_out.push(Edge::new(j, EdgeKind::MachineSucc));
+                    indv.operations[j].machine_pred = Some(pred_id);
+                } else if neighs.succ.is_some() {
+                    let succ_id = unsafe { neighs.succ.unwrap_unchecked() };
+                    indv.operations[j].edges_out.push(Edge::new(succ_id, EdgeKind::MachineSucc));
+                    indv.operations[succ_id].machine_pred = Some(j);
+                }
 
                 if g > n {
                     break;

--- a/solver/src/problem/fitness.rs
+++ b/solver/src/problem/fitness.rs
@@ -110,12 +110,12 @@ impl JsspFitness {
                 // It is possible that the most recently scheduled job is **not** the actual last on the
                 // machine. I believe there migtht be a situation where the job is scheduled
                 // before the last one. See notes on "Machine model" attached to paper.
-                if let Some(last_sch_op) = indv.machines[op_j_machine].last_scheduled_op {
-                    indv.operations[last_sch_op]
-                        .edges_out
-                        .push(Edge::new(j, EdgeKind::MachineSucc));
-                    indv.operations[j].machine_pred = Some(last_sch_op);
-                }
+                // if let Some(last_sch_op) = indv.machines[op_j_machine].last_scheduled_op {
+                //     indv.operations[last_sch_op]
+                //         .edges_out
+                //         .push(Edge::new(j, EdgeKind::MachineSucc));
+                //     indv.operations[j].machine_pred = Some(last_sch_op);
+                // }
 
                 let neighs = indv.machines[op_j_machine].reserve(finish_time_j - op_j_duration..finish_time_j, j);
 

--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -46,7 +46,7 @@ pub fn get_run_config(instance: &JsspInstance, config: &Config) -> RunConfig {
 
 pub trait Solver {
     /// Run solver for given instance
-    fn run(&mut self, instance: JsspInstance, run_config: RunConfig);
+    fn run(&mut self, instance: JsspInstance, run_config: RunConfig) -> anyhow::Result<()>;
 
     /// Return short description of the solver, e.g. mentioning the paper that the implementation
     /// bases on or simply solver name. Default Implementation returns None.
@@ -61,7 +61,7 @@ pub trait Solver {
 pub struct Goncalves2005;
 
 impl Solver for Goncalves2005 {
-    fn run(&mut self, instance: JsspInstance, run_config: RunConfig) {
+    fn run(&mut self, instance: JsspInstance, run_config: RunConfig) -> anyhow::Result<()> {
         info!(
             "Running {} solver",
             self.describe().expect("No solver description provided")
@@ -80,6 +80,8 @@ impl Solver for Goncalves2005 {
             .set_population_size(run_config.pop_size)
             .build()
             .run();
+
+        anyhow::Ok(())
     }
 
     fn describe(&self) -> Option<String> {
@@ -94,7 +96,7 @@ impl Solver for Goncalves2005 {
 pub struct RandomSearch;
 
 impl Solver for RandomSearch {
-    fn run(&mut self, instance: JsspInstance, run_config: RunConfig) {
+    fn run(&mut self, instance: JsspInstance, run_config: RunConfig) -> anyhow::Result<()> {
         info!(
             "Running {} solver",
             self.describe().expect("No solver description provided")
@@ -112,6 +114,8 @@ impl Solver for RandomSearch {
             .set_population_size(run_config.pop_size)
             .build()
             .run();
+
+        anyhow::Ok(())
     }
 
     fn describe(&self) -> Option<String> {
@@ -126,7 +130,7 @@ impl Solver for RandomSearch {
 pub struct Goncalves2005MidPoint;
 
 impl Solver for Goncalves2005MidPoint {
-    fn run(&mut self, instance: JsspInstance, run_config: RunConfig) {
+    fn run(&mut self, instance: JsspInstance, run_config: RunConfig) -> anyhow::Result<()> {
         info!(
             "Running {} solver",
             self.describe().expect("No solver description provided")
@@ -145,6 +149,8 @@ impl Solver for Goncalves2005MidPoint {
             .set_population_size(run_config.pop_size)
             .build()
             .run();
+
+        anyhow::Ok(())
     }
 
     fn describe(&self) -> Option<String> {
@@ -159,7 +165,7 @@ impl Solver for Goncalves2005MidPoint {
 pub struct Goncalves2005DoubleMidPoint;
 
 impl Solver for Goncalves2005DoubleMidPoint {
-    fn run(&mut self, instance: JsspInstance, run_config: RunConfig) {
+    fn run(&mut self, instance: JsspInstance, run_config: RunConfig) -> anyhow::Result<()> {
         info!(
             "Running {} solver",
             self.describe().expect("No solver description provided")
@@ -178,6 +184,8 @@ impl Solver for Goncalves2005DoubleMidPoint {
             .set_population_size(run_config.pop_size)
             .build()
             .run();
+
+        anyhow::Ok(())
     }
 
     fn describe(&self) -> Option<String> {


### PR DESCRIPTION
- Make run return result in solver
- Remove mailing & allow for setting grant in env file
- Remove leftover
- Improve comments on t_g
- Add temporary warning to detect schedule-in-between situations
- important comments & assertions
- Fix invalid machine successors edges being put in graph during schedule decoding.

## Description <!-- Please describe the motivation & changes introduced by this PR -->

## Linked issues <!-- Please use "Resolves #<issue_no> syntax in case this PR should be linked to an issue -->

## Important implementation details <!-- if any, optional section -->
