### PR TITLE
fix(solver): invalid finish times used for preparing summary

### DIFF
--- a/ecdk/src/ecdk/data/processing.py
+++ b/ecdk/src/ecdk/data/processing.py
@@ -33,10 +33,10 @@ def process_experiment_data(exp: Experiment, data: JoinedExperimentData, outdir:
         print(f"\tProcessing series {sid}: ")
         ok, schedule, errstr = validate_solution_string_in_context_of_instance(md.solution_string, instance, md.fitness)
 
-        # if ok:
-        #     print('OK')
-        # else:
-        #     print(f'ERR ({errstr})')
+        if ok:
+            print('OK')
+        else:
+            print(f'ERR ({errstr})')
 
         if should_plot:
             visualise_instance_solution(exp, instance, sid, exp_plotdir)


### PR DESCRIPTION
## Description <!-- Please describe the motivation & changes introduced by this PR -->

Issue details can be found in #149. This PR solved the problem by finding topological order of operations in `on_end` callback, and then,
basing on the order it reconstructs the schedule from graph using "greedy" method.

## Linked issues <!-- Please use "Resolves #<issue_no> syntax in case this PR should be linked to an issue -->

Fixes #149

## Important implementation details <!-- if any, optional section -->
