### PR TITLE
fix(solver): change dfs implementation so that each vertex is on stack exactly once

### DIFF
--- a/solver/src/problem/fitness.rs
+++ b/solver/src/problem/fitness.rs
@@ -124,7 +124,9 @@ impl JsspFitness {
                     let succ_id = unsafe { neighs.succ.unwrap_unchecked() };
 
                     let machine_pred = &mut indv.operations[pred_id];
+
                     assert!(machine_pred.edges_out.len() == 2);
+
                     machine_pred.edges_out.pop();
                     machine_pred.edges_out.push(Edge::new(j, EdgeKind::MachineSucc));
 
@@ -134,12 +136,16 @@ impl JsspFitness {
                     indv.operations[succ_id].machine_pred = Some(j);
                 } else if neighs.pred.is_some() {
                     let pred_id = unsafe { neighs.pred.unwrap_unchecked() };
+
                     let machine_pred = &mut indv.operations[pred_id];
+
                     assert!(machine_pred.edges_out.len() == 1);
+                    
                     machine_pred.edges_out.push(Edge::new(j, EdgeKind::MachineSucc));
                     indv.operations[j].machine_pred = Some(pred_id);
                 } else if neighs.succ.is_some() {
                     let succ_id = unsafe { neighs.succ.unwrap_unchecked() };
+
                     indv.operations[j].edges_out.push(Edge::new(succ_id, EdgeKind::MachineSucc));
                     indv.operations[succ_id].machine_pred = Some(j);
                 }


### PR DESCRIPTION
## Description <!-- Please describe the motivation & changes introduced by this PR -->

Change DFS implementation in deteermining critical path & distance, so that each vertex is on stack exactly once. 
This also simplifies implementation a bit and possibly fiex a bug I've just noticed when writing this description: previous implementation
pushed all neighbours on stack before jumping onto procesing another -- this could lead to non-dfs-like behaviour? Not sure really.

## Linked issues <!-- Please use "Resolves #<issue_no> syntax in case this PR should be linked to an issue -->

Closes #151

## Important implementation details <!-- if any, optional section -->
