### PR TITLE
refact(solver): remove duplicated state in form of `finish_times` array

### DIFF
--- a/solver/src/problem.rs
+++ b/solver/src/problem.rs
@@ -120,6 +120,8 @@ impl Operation {
             0
         );
 
+        self.critical_path_edge = None;
+
         // TODO: Should we zero `critical_path_edge` and `critical_distance` here?
         // Why is it not done?
     }

--- a/solver/src/problem/fitness.rs
+++ b/solver/src/problem/fitness.rs
@@ -225,13 +225,13 @@ impl JsspFitness {
                 // space to store only the direct predecessor (list of direct predecessors?).
                 if op.id != indv.operations.len() - 1 {
                     if let Some(direct_pred_id) = op.preds.last() {
-                        if indv.operations[*direct_pred_id].finish_time.unwrap() as f64 > time as f64 + delay {
+                        if indv.operations[*direct_pred_id].finish_time.unwrap_or(usize::MAX) as f64 > time as f64 + delay {
                             return false;
                         }
                     }
                 } else {
                     for &pred in op.preds.iter() {
-                        if indv.operations[pred].finish_time.unwrap() as f64 > time as f64 + delay {
+                        if indv.operations[pred].finish_time.unwrap_or(usize::MAX) as f64 > time as f64 + delay {
                             return false;
                         }
                     }

--- a/solver/src/problem/fitness.rs
+++ b/solver/src/problem/fitness.rs
@@ -200,7 +200,7 @@ impl JsspFitness {
 
         indv.operations
             .iter()
-            .filter(|op| op.finish_time.is_some())
+            .filter(|op| op.finish_time.is_none())
             .filter(|op| {
                 // It is assumed here, that dependencies are in order
 


### PR DESCRIPTION
## Description <!-- Please describe the motivation & changes introduced by this PR -->

Issue described in #150. This PR removes mentioned array & replaces its usages with state stored in operation themselves. 

## Linked issues <!-- Please use "Resolves #<issue_no> syntax in case this PR should be linked to an issue -->

Closes #150

## Important implementation details <!-- if any, optional section -->
