### PR TITLE
fix(solver): discrepancies from paper in solver implementation

### DIFF
--- a/ecdk/config/cfg_400_doubled.json
+++ b/ecdk/config/cfg_400_doubled.json
@@ -1,0 +1,4 @@
+{
+  "n_gen": 400,
+  "solver_type": "double_singlepoint"
+}

--- a/solver/src/problem/crossover.rs
+++ b/solver/src/problem/crossover.rs
@@ -31,7 +31,7 @@ impl CrossoverOperator<JsspIndividual> for JsspCrossover {
         let mask = thread_rng().sample_iter(self.distr).take(chromosome_len);
 
         for (locus, val) in mask.enumerate() {
-            if val <= 0.6 {
+            if val <= 0.7 {
                 child_1_ch.push(parent_1.chromosome()[locus]);
                 child_2_ch.push(parent_2.chromosome()[locus]);
             } else {

--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -68,7 +68,7 @@ impl Solver for Goncalves2005 {
         );
 
         ga::Builder::new()
-            .set_selection_operator(selection::Rank::new())
+            .set_selection_operator(selection::Random::new())
             .set_crossover_operator(JsspCrossover::new())
             .set_mutation_operator(mutation::Identity::new())
             .set_population_generator(JsspPopProvider::new(instance.clone()))
@@ -137,7 +137,7 @@ impl Solver for Goncalves2005MidPoint {
         );
 
         ga::Builder::new()
-            .set_selection_operator(selection::Rank::new())
+            .set_selection_operator(selection::Random::new())
             .set_crossover_operator(MidPoint::new())
             .set_mutation_operator(mutation::Identity::new())
             .set_population_generator(JsspPopProvider::new(instance.clone()))
@@ -172,7 +172,7 @@ impl Solver for Goncalves2005DoubleMidPoint {
         );
 
         ga::Builder::new()
-            .set_selection_operator(selection::Rank::new())
+            .set_selection_operator(selection::Random::new())
             .set_crossover_operator(DoubledCrossover::new(instance.cfg.n_ops * 2))
             .set_mutation_operator(mutation::Identity::new())
             .set_population_generator(JsspPopProvider::new(instance.clone()))


### PR DESCRIPTION
## Description <!-- Please describe the motivation & changes introduced by this PR -->

For some reason solvers were using `Rank` selection instead of `Random` (in paper they explicitly describe that individuals for crossover are chosen randomly).

Also in crossover operator they toss biased coin with 0.7 prob, not 0.6...

