### PR TITLE
feat(solver): allow for controlling elitism & sampling rate via CLI, groundwork for individual telemetry, multicpu HQ worker experiment

### DIFF
--- a/ecdk/scripts/setup_hyperqueue.sh
+++ b/ecdk/scripts/setup_hyperqueue.sh
@@ -26,14 +26,27 @@ nohup hq server start &
 sleep 5
 
 # Enable automatic allocation (create queue)
+# hq alloc add slurm \
+#   --workers-per-alloc 1 \
+#   --max-worker-count 48 \
+#   --backlog 36 \
+#   --idle-timeout 1m \
+#   --time-limit 9h \
+#   -- \
+#   --partition=${MY_PARTITION} \
+#   --account=${MY_GRANT_RES_CPU} \
+#   --mem-per-cpu=256M
+
+
+# Experiment with 2 CPU workers
 hq alloc add slurm \
-  --time-limit 6h \
   --workers-per-alloc 1 \
   --max-worker-count 48 \
   --backlog 36 \
   --idle-timeout 1m \
+  --time-limit 9h \
+  --cpus 2 \
   -- \
   --partition=${MY_PARTITION} \
   --account=${MY_GRANT_RES_CPU} \
   --mem-per-cpu=256M
-

--- a/ecdk/src/ecdk/data/processing.py
+++ b/ecdk/src/ecdk/data/processing.py
@@ -66,7 +66,7 @@ def process_experiment_batch_output(batch: list[Experiment], outdir: Optional[Pa
         print("Processing experiments data in multiprocess context...")
         from multiprocessing import get_context
         with get_context("spawn").Pool(process_count) as pool:
-            validation_results = pool.starmap(process_experiment_data, zip(batch, data, it.repeat(outdir), it.repeat(should_plot)))
+            validation_results = pool.starmap(process_experiment_data, tqdm(zip(batch, data, it.repeat(outdir), it.repeat(should_plot)), total=len(batch)))
 
     for result in filter(lambda res: not res.ok, validation_results):
         print(f"[ERROR] Experiment: {result.expname} has {len(result.corrupted_series)} corrupted series")

--- a/ecdk/src/ecdk/data/processing.py
+++ b/ecdk/src/ecdk/data/processing.py
@@ -76,6 +76,7 @@ def process_experiment_batch_output(batch: list[Experiment], outdir: Optional[Pa
     # As there are not mechanisms for handling (skipping during processing) corrupted data
     # it is best to just terminate processing.
     if has_corrupted_data:
+        print("Validation: ERR")
         exit(1)
     else:
         print("Validation: OK")

--- a/ecdk/src/ecdk/data/processing.py
+++ b/ecdk/src/ecdk/data/processing.py
@@ -37,8 +37,8 @@ def process_experiment_data(exp: Experiment, data: JoinedExperimentData, outdir:
         if not ok:
             invalid_series.append((sid, errstr))
 
-        if should_plot:
-            visualise_instance_solution(exp, instance, sid, exp_plotdir)
+        # if should_plot:
+        #     visualise_instance_solution(exp, instance, sid, exp_plotdir)
         instance.reset()
 
     if should_plot:
@@ -77,6 +77,8 @@ def process_experiment_batch_output(batch: list[Experiment], outdir: Optional[Pa
     # it is best to just terminate processing.
     if has_corrupted_data:
         exit(1)
+    else:
+        print("Validation: OK")
 
     tabledir = get_main_tabledir(outdir) if outdir is not None else None
     global_df = compute_global_exp_stats(batch, data, tabledir)

--- a/ecdk/src/ecdk/data/stat.py
+++ b/ecdk/src/ecdk/data/stat.py
@@ -45,6 +45,7 @@ def compute_global_exp_stats(batch: list[Experiment], data: list[JoinedExperimen
             ])
             .collect()
         )
+
         # Avg. number of improvements
         df = (
             expdata.newbest.lazy()
@@ -57,6 +58,7 @@ def compute_global_exp_stats(batch: list[Experiment], data: list[JoinedExperimen
             .collect()
             .hstack(df, in_place=True)  # stacking two smaller dframes here
         )
+
         # Iteration time stats
         df = (
             expdata.iterinfo.lazy()

--- a/solver/src/cli.rs
+++ b/solver/src/cli.rs
@@ -37,6 +37,16 @@ pub struct Args {
     /// `doubled_crossover`.
     #[arg(short = 's', long = "solver-type")]
     pub solver_type: Option<String>,
+
+    /// Elitims rate passed to JsspCrossover operator in solvers that utilise it.
+    /// See JsspCrossover implementation to understand its meaning exactly.
+    #[arg(long = "elitism-rate")]
+    pub elitism_rate: Option<f64>,
+
+    /// Sampling rate passed to JsspCrossover operator in solvers that utilise it
+    /// See JsspCrossover implementation to understand its meaning exactly.
+    #[arg(long = "sampling-rate")]
+    pub sampling_rate: Option<f64>,
 }
 
 fn validate_args(args: &Args) -> Result<(), String> {

--- a/solver/src/config.rs
+++ b/solver/src/config.rs
@@ -31,6 +31,14 @@ pub struct Config {
 
     /// Solver type to run. Available options: `default`, `randomsearch`, `midpoint`, `double_singlepoint`.
     pub solver_type: String,
+
+    /// Elitims rate passed to JsspCrossover operator in solvers that utilise it.
+    /// See JsspCrossover implementation to understand its meaning exactly.
+    pub elitism_rate: f64,
+
+    /// Sampling rate passed to JsspCrossover operator in solvers that utilise it
+    /// See JsspCrossover implementation to understand its meaning exactly.
+    pub sampling_rate: f64,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -41,6 +49,8 @@ pub struct PartialConfig {
     pub pop_size: Option<usize>,
     pub delay_const_factor: Option<f64>,
     pub solver_type: Option<String>,
+    pub elitism_rate: Option<f64>,
+    pub sampling_rate: Option<f64>,
 }
 
 impl PartialConfig {
@@ -52,6 +62,8 @@ impl PartialConfig {
             pop_size: None,
             delay_const_factor: None,
             solver_type: None,
+            elitism_rate: None,
+            sampling_rate: None,
         }
     }
 }
@@ -85,6 +97,8 @@ impl TryFrom<PartialConfig> for Config {
             solver_type: partial_cfg
                 .solver_type
                 .unwrap_or(String::from(SOLVER_TYPE_DEFAULT)),
+            elitism_rate: partial_cfg.elitism_rate.unwrap_or(0.1),  // Defaults from paper
+            sampling_rate: partial_cfg.sampling_rate.unwrap_or(0.2),  // Defaults from paper
         })
     }
 }
@@ -119,6 +133,12 @@ impl TryFrom<Args> for Config {
         }
         if let Some(solver_type) = args.solver_type {
             partial_cfg.solver_type = Some(solver_type);
+        }
+        if let Some(elitism_rate) = args.elitism_rate {
+            partial_cfg.elitism_rate = Some(elitism_rate);
+        }
+        if let Some(sampling_rate) = args.sampling_rate {
+            partial_cfg.sampling_rate = Some(sampling_rate);
         }
 
         Config::try_from(partial_cfg)

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -5,6 +5,7 @@ mod parse;
 mod problem;
 mod solver;
 mod util;
+mod stats;
 
 use config::Config;
 use solver::registry::SolverRegistry;

--- a/solver/src/problem/crossover.rs
+++ b/solver/src/problem/crossover.rs
@@ -3,6 +3,8 @@
 use ecrs::{ga::individual::IndividualTrait, prelude::crossover::CrossoverOperator};
 use rand::{rngs::ThreadRng, thread_rng, Rng};
 
+use crate::stats::IndividualTelemetry;
+
 use super::individual::JsspIndividual;
 
 pub struct JsspCrossover {
@@ -43,9 +45,11 @@ impl CrossoverOperator<JsspIndividual> for JsspCrossover {
         let mut child_1 = parent_1.clone();
         let mut child_2 = parent_2.clone();
         child_1.is_fitness_valid = false;
-        child_2.is_fitness_valid = false;
         child_1.chromosome = child_1_ch;
+        child_1.telemetry = IndividualTelemetry::new();
+        child_2.is_fitness_valid = false;
         child_2.chromosome = child_2_ch;
+        child_2.telemetry = IndividualTelemetry::new();
 
         (child_1, child_2)
     }
@@ -97,7 +101,9 @@ impl CrossoverOperator<JsspIndividual> for MidPoint {
         }
 
         child_1.is_fitness_valid = false;
+        child_1.telemetry = IndividualTelemetry::new();
         child_2.is_fitness_valid = false;
+        child_2.telemetry = IndividualTelemetry::new();
 
         (child_1, child_2)
     }
@@ -160,7 +166,9 @@ impl CrossoverOperator<JsspIndividual> for DoubledCrossover {
         }
 
         child_1.is_fitness_valid = false;
+        child_1.telemetry = IndividualTelemetry::new();
         child_2.is_fitness_valid = false;
+        child_2.telemetry = IndividualTelemetry::new();
 
         (child_1, child_2)
     }

--- a/solver/src/problem/crossover.rs
+++ b/solver/src/problem/crossover.rs
@@ -168,7 +168,7 @@ impl CrossoverOperator<JsspIndividual> for DoubledCrossover {
 
 #[cfg(test)]
 mod test {
-    use ecrs::ga::{operators::crossover::CrossoverOperator};
+    use ecrs::ga::operators::crossover::CrossoverOperator;
     use itertools::Itertools;
 
     use crate::problem::{

--- a/solver/src/problem/individual.rs
+++ b/solver/src/problem/individual.rs
@@ -39,6 +39,7 @@ impl JsspIndividual {
     pub(super) fn reset(&mut self) {
         self.machines.iter_mut().for_each(|machine| machine.reset());
         self.operations.iter_mut().for_each(|op| op.reset());
+        // TODO: consider cleaning `is_dirty` flag here
     }
 }
 

--- a/solver/src/problem/individual.rs
+++ b/solver/src/problem/individual.rs
@@ -1,5 +1,7 @@
 use ecrs::ga::individual::IndividualTrait;
 
+use crate::stats::IndividualTelemetry;
+
 use super::{Machine, Operation};
 
 /// Models single solution to the JSSP problem instance
@@ -21,17 +23,20 @@ pub struct JsspIndividual {
     pub is_fitness_valid: bool,
     /// TODO: Determine what I've used it for
     pub is_dirty: bool,
+
+    pub telemetry: IndividualTelemetry
 }
 
 impl JsspIndividual {
-    pub fn new(chromosome: Vec<f64>, ops: Vec<Operation>, machines: Vec<Machine>, fitness: usize) -> Self {
+    pub fn new(chromosome: Vec<f64>, operations: Vec<Operation>, machines: Vec<Machine>, fitness: usize) -> Self {
         Self {
             chromosome,
-            operations: ops,
+            operations,
             machines,
             fitness,
             is_fitness_valid: false,
             is_dirty: false,
+            telemetry: IndividualTelemetry::new(),
         }
     }
 
@@ -103,6 +108,7 @@ impl From<Vec<f64>> for JsspIndividual {
             fitness: usize::MAX,
             is_fitness_valid: false,
             is_dirty: false,
+            telemetry: IndividualTelemetry::new(),
         }
     }
 }

--- a/solver/src/problem/replacement.rs
+++ b/solver/src/problem/replacement.rs
@@ -1,24 +1,28 @@
 use ecrs::prelude::{population::PopulationGenerator, replacement::ReplacementOperator};
 
+use crate::stats::{StatsEngine, StatsAware};
+
 use super::{individual::JsspIndividual, population::JsspPopProvider};
 
-pub struct JsspReplacement {
+pub struct JsspReplacement<'stats> {
     pop_gen: JsspPopProvider,
     elite_rate: f64,
     sample_rate: f64,
+    stats_engine: Option<&'stats StatsEngine>
 }
 
-impl JsspReplacement {
+impl <'stats> JsspReplacement<'stats> {
     pub fn new(pop_gen: JsspPopProvider, elite_rate: f64, sample_rate: f64) -> Self {
         Self {
             pop_gen,
             elite_rate,
             sample_rate,
+            stats_engine: None,
         }
     }
 }
 
-impl ReplacementOperator<JsspIndividual> for JsspReplacement {
+impl <'stats> ReplacementOperator<JsspIndividual> for JsspReplacement<'stats> {
     fn apply(
         &mut self,
         mut population: Vec<JsspIndividual>,
@@ -63,17 +67,24 @@ impl ReplacementOperator<JsspIndividual> for JsspReplacement {
     }
 }
 
-pub struct ReplaceWithRandomPopulation {
-    pop_gen: JsspPopProvider,
-}
-
-impl ReplaceWithRandomPopulation {
-    pub fn new(pop_gen: JsspPopProvider) -> Self {
-        Self { pop_gen }
+impl <'stats> StatsAware<'stats> for JsspReplacement<'stats> {
+    fn set_stats_engine(&mut self, engine: &'stats StatsEngine) {
+        self.stats_engine = Some(engine)
     }
 }
 
-impl ReplacementOperator<JsspIndividual> for ReplaceWithRandomPopulation {
+pub struct ReplaceWithRandomPopulation<'stats> {
+    pop_gen: JsspPopProvider,
+    stats_engine: Option<&'stats StatsEngine>,
+}
+
+impl <'stats> ReplaceWithRandomPopulation<'stats> {
+    pub fn new(pop_gen: JsspPopProvider) -> Self {
+        Self { pop_gen, stats_engine: None }
+    }
+}
+
+impl <'stats> ReplacementOperator<JsspIndividual> for ReplaceWithRandomPopulation<'stats> {
     fn apply(
         &mut self,
         population: Vec<JsspIndividual>,
@@ -84,5 +95,11 @@ impl ReplacementOperator<JsspIndividual> for ReplaceWithRandomPopulation {
 
     fn requires_children_fitness(&self) -> bool {
         false
+    }
+}
+
+impl <'stats> StatsAware<'stats> for ReplaceWithRandomPopulation<'stats> {
+    fn set_stats_engine(&mut self, engine: &'stats StatsEngine) {
+        self.stats_engine = Some(engine);
     }
 }

--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -74,12 +74,20 @@ impl Solver for Goncalves2005 {
             self.describe().expect("No solver description provided")
         );
 
+        let stats_engine = StatsEngine::new();
+        let mut replacement_op = JsspReplacement::new(
+            JsspPopProvider::new(instance.clone()),
+            run_config.elitism_rate,
+            run_config.sampling_rate,
+        );
+        replacement_op.set_stats_engine(&stats_engine);
+
         ga::Builder::new()
             .set_selection_operator(selection::Random::new())
             .set_crossover_operator(JsspCrossover::new())
             .set_mutation_operator(mutation::Identity::new())
-            .set_population_generator(JsspPopProvider::new(instance.clone()))
-            .set_replacement_operator(JsspReplacement::new(JsspPopProvider::new(instance), 0.1, 0.2))
+            .set_population_generator(JsspPopProvider::new(instance))
+            .set_replacement_operator(replacement_op)
             .set_fitness(JsspFitness::new(1.5))
             .set_probe(JsspProbe::new())
             // .set_max_duration(std::time::Duration::from_secs(30))
@@ -109,13 +117,17 @@ impl Solver for RandomSearch {
             self.describe().expect("No solver description provided")
         );
 
+        let stats_engine = StatsEngine::new();
+        let mut replacement_op = ReplaceWithRandomPopulation::new(JsspPopProvider::new(instance.clone()));
+        replacement_op.set_stats_engine(&stats_engine);
+
         ga::Builder::new()
-            .set_population_generator(JsspPopProvider::new(instance.clone()))
+            .set_population_generator(JsspPopProvider::new(instance))
             .set_fitness(JsspFitness::new(1.5))
             .set_selection_operator(EmptySelection::new())
             .set_crossover_operator(NoopCrossover::new())
             .set_mutation_operator(mutation::Identity::new())
-            .set_replacement_operator(ReplaceWithRandomPopulation::new(JsspPopProvider::new(instance)))
+            .set_replacement_operator(replacement_op)
             .set_probe(JsspProbe::new())
             .set_max_generation_count(run_config.n_gen)
             .set_population_size(run_config.pop_size)
@@ -143,12 +155,16 @@ impl Solver for Goncalves2005MidPoint {
             self.describe().expect("No solver description provided")
         );
 
+        let stats_engine = StatsEngine::new();
+        let mut replacement_op = JsspReplacement::new(JsspPopProvider::new(instance.clone()), 0.1, 0.2);
+        replacement_op.set_stats_engine(&stats_engine);
+
         ga::Builder::new()
             .set_selection_operator(selection::Random::new())
             .set_crossover_operator(MidPoint::new())
             .set_mutation_operator(mutation::Identity::new())
-            .set_population_generator(JsspPopProvider::new(instance.clone()))
-            .set_replacement_operator(JsspReplacement::new(JsspPopProvider::new(instance), 0.1, 0.2))
+            .set_population_generator(JsspPopProvider::new(instance))
+            .set_replacement_operator(replacement_op)
             .set_fitness(JsspFitness::new(1.5))
             .set_probe(JsspProbe::new())
             // .set_max_duration(std::time::Duration::from_secs(30))
@@ -178,12 +194,16 @@ impl Solver for Goncalves2005DoubleMidPoint {
             self.describe().expect("No solver description provided")
         );
 
+        let stats_engine = StatsEngine::new();
+        let mut replacement_op = JsspReplacement::new(JsspPopProvider::new(instance.clone()), 0.1, 0.2);
+        replacement_op.set_stats_engine(&stats_engine);
+
         ga::Builder::new()
             .set_selection_operator(selection::Random::new())
             .set_crossover_operator(DoubledCrossover::new(instance.cfg.n_ops * 2))
             .set_mutation_operator(mutation::Identity::new())
-            .set_population_generator(JsspPopProvider::new(instance.clone()))
-            .set_replacement_operator(JsspReplacement::new(JsspPopProvider::new(instance), 0.1, 0.2))
+            .set_population_generator(JsspPopProvider::new(instance))
+            .set_replacement_operator(replacement_op)
             .set_fitness(JsspFitness::new(1.5))
             .set_probe(JsspProbe::new())
             // .set_max_duration(std::time::Duration::from_secs(30))

--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -20,28 +20,35 @@ use crate::{
         selection::EmptySelection,
         JsspInstance,
     },
+    stats::{StatsAware, StatsEngine},
 };
 
 #[derive(Clone, Copy)]
 pub struct RunConfig {
     pop_size: usize,
     n_gen: usize,
+
+    /// Elitims rate passed to JsspCrossover operator in solvers that utilise it.
+    /// See JsspCrossover implementation to understand its meaning exactly.
+    elitism_rate: f64,
+
+    /// Sampling rate passed to JsspCrossover operator in solvers that utilise it
+    /// See JsspCrossover implementation to understand its meaning exactly.
+    sampling_rate: f64,
 }
 
 pub fn get_run_config(instance: &JsspInstance, config: &Config) -> RunConfig {
-    let pop_size = if let Some(ps) = config.pop_size {
-        ps // Overrided by user
-    } else {
-        instance.cfg.n_ops * 2 // Defined in paper
-    };
+    // TODO: Create single place with solver defaults, right now its here
+    // and in config creation...
 
-    let n_gen = if let Some(ng) = config.n_gen {
-        ng // Overrided by user
-    } else {
-        400 // Defined in paper
-    };
+    // TODO: Do I really need this RunConfig structure? Maybe just pass config around
 
-    RunConfig { pop_size, n_gen }
+    RunConfig {
+        pop_size: config.pop_size.unwrap_or(instance.cfg.n_ops * 2),
+        n_gen: config.n_gen.unwrap_or(400),
+        elitism_rate: config.elitism_rate,
+        sampling_rate: config.sampling_rate,
+    }
 }
 
 pub trait Solver {

--- a/solver/src/stats.rs
+++ b/solver/src/stats.rs
@@ -1,0 +1,59 @@
+use std::{rc::Rc, cell::RefCell};
+
+pub trait StatsAware<'stats> {
+    fn set_stats_engine(&mut self, engine: &'stats StatsEngine);
+}
+
+pub struct Stats {
+    age_sum: usize,
+    individual_count: usize,
+    crossover_involvement_max: usize,
+    crossover_involvement_min: usize,
+}
+
+impl Stats {
+    pub fn new(age_sum: usize, individual_count: usize) -> Self {
+        Self {
+            age_sum,
+            individual_count,
+            crossover_involvement_max: usize::MIN,
+            crossover_involvement_min: usize::MAX,
+        }
+    }
+}
+
+impl Default for Stats {
+    fn default() -> Self {
+        Self::new(0, 0)
+    }
+}
+
+pub struct StatsEngine {
+    pub stats: Rc<RefCell<Stats>>
+}
+
+impl StatsEngine {
+    pub fn new() -> Self {
+        Self {
+            stats: Rc::new(RefCell::new(Stats::default())),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct IndividualTelemetry {
+    /// Generation in which this individual was created
+    pub birth_generation: Option<usize>,
+
+    // Number of crossovers this individual was part of
+    pub crossover_involvement: Option<usize>,
+}
+
+impl IndividualTelemetry {
+    pub fn new() -> Self {
+        Self {
+            birth_generation: None,
+            crossover_involvement: None,
+        }
+    }
+}


### PR DESCRIPTION
## Description <!-- Please describe the motivation & changes introduced by this PR -->

It is now possible to control `elitism_rate` & `sampling_rate` via CLI. Note that only certain crossover operators do use it.

Also added telemetry structure to `JsspIndividual` struct. It is not possible to track the stats yet, changes to ECRS are needed first.

