### PR TITLE
fix(solver): pass `elitism_rate` & `sampling_rate` instead of hardcoded values to non-default solvers

### DIFF
--- a/solver/src/solver.rs
+++ b/solver/src/solver.rs
@@ -156,7 +156,11 @@ impl Solver for Goncalves2005MidPoint {
         );
 
         let stats_engine = StatsEngine::new();
-        let mut replacement_op = JsspReplacement::new(JsspPopProvider::new(instance.clone()), 0.1, 0.2);
+        let mut replacement_op = JsspReplacement::new(
+            JsspPopProvider::new(instance.clone()),
+            run_config.elitism_rate,
+            run_config.sampling_rate,
+        );
         replacement_op.set_stats_engine(&stats_engine);
 
         ga::Builder::new()
@@ -195,7 +199,11 @@ impl Solver for Goncalves2005DoubleMidPoint {
         );
 
         let stats_engine = StatsEngine::new();
-        let mut replacement_op = JsspReplacement::new(JsspPopProvider::new(instance.clone()), 0.1, 0.2);
+        let mut replacement_op = JsspReplacement::new(
+            JsspPopProvider::new(instance.clone()),
+            run_config.elitism_rate,
+            run_config.sampling_rate,
+        );
         replacement_op.set_stats_engine(&stats_engine);
 
         ga::Builder::new()


### PR DESCRIPTION
## Description <!-- Please describe the motivation & changes introduced by this PR -->

Fixing a bug where these parameters (see title) were passed only to default solver while others
were still using hardcoded values.

## Linked issues <!-- Please use "Resolves #<issue_no> syntax in case this PR should be linked to an issue -->

Closes #171

