### PR TITLE
feat: dump timestamps of batch & solver runs, fix usages of `total_dur` & plot with best_fitness & compound plot

### DIFF
--- a/ecdk/src/ecdk/command/run.py
+++ b/ecdk/src/ecdk/command/run.py
@@ -2,7 +2,6 @@ from cli.args import RunCmdArgs
 from experiment.runner import LocalExperimentBatchRunner, HyperQueueRunner
 from experiment.solver import SolverProxy
 from experiment.model import (
-    ExperimentResult,
     ExperimentConfig,
     Experiment,
     ExperimentBatch,

--- a/ecdk/src/ecdk/command/run.py
+++ b/ecdk/src/ecdk/command/run.py
@@ -13,7 +13,7 @@ from core.tools import (
     exp_name_from_input_file,
     output_dir_for_experiment_with_name,
     attach_timestamp_to_dir,
-    current_timestamp
+    current_timestamp_iso8601
 )
 from core.fs import initialize_file_hierarchy
 from context import Context
@@ -27,8 +27,10 @@ def run(ctx: Context, args: RunCmdArgs):
 
     base_dir = args.output_dir
 
+    start_timestamp = current_timestamp_iso8601()
+
     if not ctx.is_ares and args.attach_timestamp:
-        base_dir = attach_timestamp_to_dir(base_dir, current_timestamp())
+        base_dir = attach_timestamp_to_dir(base_dir, start_timestamp)
 
     batch = []
     for file in input_files:
@@ -50,7 +52,10 @@ def run(ctx: Context, args: RunCmdArgs):
         )
 
     solver_config = SolverConfigFile(args.config_file) if args.config_file else None
-    batch = ExperimentBatch(output_dir=base_dir, experiments=batch, solver_config=solver_config)
+    batch = ExperimentBatch(output_dir=base_dir,
+                            experiments=batch,
+                            solver_config=solver_config,
+                            start_time=start_timestamp)
 
     # Create file hierarchy & dump configuration data
     initialize_file_hierarchy(batch)

--- a/ecdk/src/ecdk/core/conversion.py
+++ b/ecdk/src/ecdk/core/conversion.py
@@ -1,26 +1,8 @@
-from typing import Dict
 from experiment.model import (
-    SeriesOutputMetadata,
     Experiment,
     InstanceMetadata,
     ExperimentConfig
 )
-
-
-def deserialize_series_metadata_from_dict(md: Dict) -> SeriesOutputMetadata:
-    return SeriesOutputMetadata(
-        solution_string=md["solution_string"],
-        hash=md["hash"],
-        fitness=md["fitness"],
-        generation_count=md["generation_count"],
-        total_time=md["total_time"],
-        chromosome=md["chromosome"],
-        age_avg=md.get("age_avg"),
-        age_max=md.get("age_max"),
-        individual_count=md.get("individual_count"),
-        crossover_involvement_max=md.get("crossover_involvement_max"),
-        crossover_involvement_min=md.get("crossover_involvement_min")
-    )
 
 
 def deserialize_experiment_from_dict(exp_dict: dict):

--- a/ecdk/src/ecdk/core/series.py
+++ b/ecdk/src/ecdk/core/series.py
@@ -4,9 +4,9 @@ from experiment.model import (
     SeriesOutputFiles,
     SeriesOutputData,
     SeriesOutput,
+    SeriesOutputMetadata,
 )
 from core.util import find_first_or_none
-from core.conversion import deserialize_series_metadata_from_dict
 import polars as pl
 import json
 
@@ -38,7 +38,7 @@ def _load_series_metadata_from_file(metadata_file: Path) -> SeriesOutputFiles:
     metadata = None
 
     with open(metadata_file, 'r') as file:
-        metadata = json.load(file, object_hook=deserialize_series_metadata_from_dict)
+        metadata = json.load(file, object_hook=SeriesOutputMetadata.from_dict)
 
     return metadata
 

--- a/ecdk/src/ecdk/core/tools.py
+++ b/ecdk/src/ecdk/core/tools.py
@@ -40,5 +40,9 @@ def current_timestamp() -> str:
     return timestamp
 
 
+def current_timestamp_iso8601() -> str:
+    return dt.datetime.now().strftime("%y%m%dT%H%M%S")
+
+
 def attach_timestamp_to_dir(directory: Path, timestamp: str) -> Path:
     return directory.joinpath(timestamp)

--- a/ecdk/src/ecdk/data/processing.py
+++ b/ecdk/src/ecdk/data/processing.py
@@ -85,7 +85,7 @@ def process_experiment_data(exp: Experiment,
                                 some_best_series,
                                 exp_plotdir)
 
-    create_plots_for_experiment(exp, data, exp_plotdir)
+    create_plots_for_experiment(exp, data, some_best_series, exp_plotdir)
 
     # compute_per_exp_stats(exp, data)
 

--- a/ecdk/src/ecdk/experiment/model.py
+++ b/ecdk/src/ecdk/experiment/model.py
@@ -287,7 +287,7 @@ class ExperimentBatch:
     solver_config: Optional[SolverConfigFile]
 
     # ISO 8601 timestamp
-    start_time: Optional[str]
+    start_time: Optional[str] = None
 
     def as_dict(self) -> dict:
         result = {

--- a/ecdk/src/ecdk/experiment/model.py
+++ b/ecdk/src/ecdk/experiment/model.py
@@ -266,6 +266,9 @@ class ExperimentBatch:
 
     solver_config: Optional[SolverConfigFile]
 
+    # ISO 8601 timestamp
+    start_time: Optional[str]
+
     def as_dict(self) -> dict:
         result = {
             "output_dir": str(self.output_dir),
@@ -274,6 +277,9 @@ class ExperimentBatch:
 
         if self.solver_config is not None:
             result["solver_config"] = self.solver_config.contents.as_dict()
+
+        if self.start_time:
+            result["start_time"] = self.start_time
 
         return result
 

--- a/ecdk/src/ecdk/experiment/model.py
+++ b/ecdk/src/ecdk/experiment/model.py
@@ -45,6 +45,26 @@ class SeriesOutputMetadata:
     individual_count: Optional[int]
     crossover_involvement_max: Optional[int]
     crossover_involvement_min: Optional[int]
+    start_timestamp: Optional[str]
+    end_timestamp: Optional[str]
+
+    @classmethod
+    def from_dict(cls, md: Dict):
+        return cls(
+            solution_string=md["solution_string"],
+            hash=md["hash"],
+            fitness=md["fitness"],
+            generation_count=md["generation_count"],
+            total_time=md["total_time"],
+            chromosome=md["chromosome"],
+            age_avg=md.get("age_avg"),
+            age_max=md.get("age_max"),
+            individual_count=md.get("individual_count"),
+            crossover_involvement_max=md.get("crossover_involvement_max"),
+            crossover_involvement_min=md.get("crossover_involvement_min"),
+            start_timestamp=md.get("start_timestamp"),
+            end_timestamp=md.get("end_timestamp"),
+        )
 
 
 @dataclass(frozen=True)

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -22,3 +22,4 @@ itertools = "0.10.2"
 rand = "0.8.5"
 anyhow = "1.0.80"
 thiserror = "1.0.57"
+time = { version = "0.3.34", features = ["formatting", "parsing"] }

--- a/solver/src/logging.rs
+++ b/solver/src/logging.rs
@@ -22,6 +22,9 @@ pub struct OutputData<'a> {
     pub individual_count: usize,
     pub crossover_involvement_max: usize,
     pub crossover_involvement_min: usize,
+
+    pub start_timestamp: String,
+    pub end_timestamp: String,
 }
 
 pub fn init_logging(

--- a/solver/src/problem/probe.rs
+++ b/solver/src/problem/probe.rs
@@ -134,7 +134,7 @@ impl<'stats> Probe<JsspIndividual> for JsspProbe<'stats> {
             target: "newbest",
             "newbest,{},{},{}",
             metadata.generation,
-            metadata.total_dur.unwrap().as_millis(),
+            metadata.total_dur.unwrap().as_millis(), // `total_dur` is accurate here
             individual.fitness
         );
     }
@@ -150,7 +150,7 @@ impl<'stats> Probe<JsspIndividual> for JsspProbe<'stats> {
             target: "popmetrics",
             "diversity,{},{},{},{diversity},{distance_avg}",
             metadata.generation,
-            metadata.total_dur.unwrap().as_millis(),
+            metadata.start_time.unwrap().elapsed().as_millis(),
             generation.len()
         );
     }
@@ -160,7 +160,7 @@ impl<'stats> Probe<JsspIndividual> for JsspProbe<'stats> {
             target: "bestingen",
             "bestingen,{},{},{}",
             metadata.generation,
-            metadata.total_dur.unwrap().as_millis(),
+            metadata.start_time.unwrap().elapsed().as_millis(),
             individual.fitness
         );
     }

--- a/solver/src/problem/probe.rs
+++ b/solver/src/problem/probe.rs
@@ -5,10 +5,13 @@ use ecrs::ga::{individual::IndividualTrait, Probe};
 use itertools::{repeat_n, Itertools};
 use log::{info, trace, warn};
 use md5;
+use time::OffsetDateTime;
 
 use crate::logging::OutputData;
 
 use super::individual::JsspIndividual;
+
+const TIME_FORMAT_STRING: &str = "[year][month][day]T[hour][minute][second].[subsecond digits:6]";
 
 pub(crate) struct JsspProbe<'stats> {
     stats_engine: &'stats StatsEngine,
@@ -100,6 +103,8 @@ impl<'stats> Probe<JsspIndividual> for JsspProbe<'stats> {
         info!(target: "newbest", "event_name,generation,total_duration,fitness");
         info!(target: "bestingen", "event_name,generation,total_duration,fitness");
         info!(target: "iterinfo", "event_name,generation,eval_time,sel_time,cross_time,mut_time,repl_time,iter_time");
+
+        self.stats_engine.stats.borrow_mut().start_timestamp = std::time::SystemTime::now();
     }
 
     fn on_initial_population_created(
@@ -306,6 +311,14 @@ impl<'stats> Probe<JsspIndividual> for JsspProbe<'stats> {
             .join("_");
 
         let hash = md5::compute(solution_string.clone());
+
+        stats.end_timestamp = std::time::SystemTime::now();
+
+        let start_timestamp: OffsetDateTime = stats.start_timestamp.into();
+        let end_timestamp: OffsetDateTime = stats.end_timestamp.into();
+
+        let time_format = time::format_description::parse(TIME_FORMAT_STRING).unwrap_or(Vec::new());
+
         let outdata = OutputData {
             solution_string,
             hash: format!("{:x}", hash),
@@ -318,6 +331,8 @@ impl<'stats> Probe<JsspIndividual> for JsspProbe<'stats> {
             individual_count: stats.individual_count,
             crossover_involvement_max: stats.crossover_involvement_max,
             crossover_involvement_min: stats.crossover_involvement_min,
+            start_timestamp: start_timestamp.format(&time_format).unwrap_or("error".into()),
+            end_timestamp: end_timestamp.format(&time_format).unwrap_or("error".into()),
         };
         let serialized_object = serde_json::to_string_pretty(&outdata).unwrap();
         info!(target: "metadata", "{serialized_object}");

--- a/solver/src/stats.rs
+++ b/solver/src/stats.rs
@@ -14,6 +14,8 @@ pub struct Stats {
     pub crossover_involvement_max: usize,
     pub crossover_involvement_min: usize,
     pub age_max: usize,
+    pub start_timestamp: std::time::SystemTime,
+    pub end_timestamp: std::time::SystemTime,
 }
 
 impl Stats {
@@ -24,6 +26,8 @@ impl Stats {
             crossover_involvement_max: usize::MIN,
             crossover_involvement_min: usize::MAX,
             age_max: usize::MIN,
+            start_timestamp: std::time::UNIX_EPOCH,
+            end_timestamp: std::time::UNIX_EPOCH,
         }
     }
 


### PR DESCRIPTION
## Description <!-- Please describe the motivation & changes introduced by this PR -->

See related issues for description.

## Linked issues <!-- Please use "Resolves #<issue_no> syntax in case this PR should be linked to an issue -->

Closes #197
Closes #200
Closes #206

