### PR TITLE
fix: missing convergence info

### DIFF
--- a/ecdk/src/ecdk/data/stat.py
+++ b/ecdk/src/ecdk/data/stat.py
@@ -232,10 +232,15 @@ def compute_convergence_iteration_per_exp(batch: list[Experiment], data: list[Jo
 
         main_df.vstack(avg_cvg_iter, in_place=True)
 
-        # print(avg_cvg_iter)
-        # print(n_converged)
-        # break
-    main_df = main_df.drop_nulls().sort(KEY_EXPNAME)
+    main_df = (
+        main_df
+        .filter(pl.col('avg_cvg_iter').is_not_null())
+        .sort(KEY_EXPNAME)
+        .with_columns((
+            # Null values occur when there is only single data point
+            pl.col('std_cvg_iter').fill_null(pl.lit(0))
+        ))
+    )
     print(main_df)
     return main_df
 


### PR DESCRIPTION
## Description <!-- Please describe the motivation & changes introduced by this PR -->

Dropping nulls in `main_df` agg table resulted in dropping rows (experiments) where there was only single solution found,
which resulted in nulls in `std_cvg_iter` column. Fixed this by filling missing standard deviations with zeros and filtering 
by nulls only in `avg_cvg_iter` which is null only in case there are no solutions.

## Linked issues <!-- Please use "Resolves #<issue_no> syntax in case this PR should be linked to an issue -->

Closes #212

