### PR TITLE
feat: parallelize data loading & validation

### DIFF
--- a/ecdk/src/ecdk/main.py
+++ b/ecdk/src/ecdk/main.py
@@ -9,7 +9,7 @@
 
 import sys
 from pathlib import Path
-print(f"cwd/src: {Path.cwd().joinpath('src')}")
+# print(f"cwd/src: {Path.cwd().joinpath('src')}")
 sys.path.append(str(Path.cwd().joinpath('src')))
 
 import polars as pl


### PR DESCRIPTION
## Description <!-- Please describe the motivation & changes introduced by this PR -->

* Parallelization of validation brings no effective speedup (just under 6 secs -> 5.5 secs)
* Parallelization of data loading is problematic, as it seems that compound objects (results of data loading per experiment)
are not transferred conrrectly between processes and for any nested object we get `None` back in parent process.

## Linked issues <!-- Please use "Resolves #<issue_no> syntax in case this PR should be linked to an issue -->

Closes #219
Closes #218

## Important implementation details <!-- if any, optional section -->
