### PR TITLE
feat(ecdk,solver): dump solver version & ecdk version to batch config file & bump python to 3.11.3

### DIFF
--- a/ecdk/pyproject.toml
+++ b/ecdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ecdk"
-version = "0.0.1-beta.1"
+version = "0.1.0"
 authors = [
   { name="Kacper Kafara", email="kacperkafara@gmail.com" }
 ]

--- a/ecdk/scripts/setup_hyperqueue.sh
+++ b/ecdk/scripts/setup_hyperqueue.sh
@@ -87,7 +87,8 @@ assert_envvar_set MY_GRANT_RES_CPU
 
 # module load python/3.10.8-gcccore-12.2.0
 # pip install -r requirements.txt
-load_module_if_needed python/3.10.8-gcccore-12.2.0
+# load_module_if_needed python/3.10.8-gcccore-12.2.0
+load_module_if_needed python/3.11.3-gcccore-12.3.0
 pip install -r requirements.txt
 
 

--- a/ecdk/src/ecdk/context/__init__.py
+++ b/ecdk/src/ecdk/context/__init__.py
@@ -1,3 +1,4 @@
+import tomllib
 from pathlib import Path
 from typing import Optional
 from core.env import (
@@ -6,6 +7,7 @@ from core.env import (
     getmap_env,
     get_runtime_name
 )
+from core.version import Version
 
 
 class Context:
@@ -19,6 +21,7 @@ class Context:
         self.long_term_cache_dir: Optional[Path] = getmap_env('MY_GROUPS_STORAGE', Path)
         self.instance_metadata_file: Optional[Path] = getmap_env('MY_INSTANCE_METADATA_FILE', Path)
         self.instances_root_dir: Optional[Path] = getmap_env('MY_INSTANCES_DIR', Path)
+        self.ecdk_version: Version = self._resolve_ecdk_version()
 
         if strict:
             assert self.runtime != RT_UNKNOWN
@@ -27,4 +30,11 @@ class Context:
             assert self.long_term_cache_dir is not None and self.long_term_cache_dir.is_dir()
             assert self.instance_metadata_file is not None and self.instance_metadata_file.is_file()
             assert self.instances_root_dir is not None and self.instances_root_dir.is_dir()
+            assert self.ecdk_version is not None and isinstance(self.ecdk_version, Version)
+
+    def _resolve_ecdk_version(self) -> Version:
+        with open("pyproject.toml", "rb") as file:
+            pyproject_file = tomllib.load(file)
+            version = pyproject_file.get('project', {}).get('version')
+            return Version.from_str(version)
 

--- a/ecdk/src/ecdk/core/version.py
+++ b/ecdk/src/ecdk/core/version.py
@@ -1,0 +1,23 @@
+class Version:
+    __slots__ = ('major', 'minor', 'patch')
+
+    def __init__(self, major: int, minor: int, patch: int):
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+
+    @classmethod
+    def from_str(cls, version_str: str):
+        print(f"Received str: {version_str}")
+        parts = version_str.split('.')
+        assert len(parts) == 3, f"Expected exactly 3 parts in version string spec, got {len(parts)}"
+        major, minor, patch = int(parts[0]), int(parts[1]), int(parts[2])
+        return cls(major, minor, patch)
+
+    def __str__(self) -> str:
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+    def __repr__(self) -> str:
+        return str(self)
+
+

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solver"
-version = "1.0.1"
+version = "1.1.1"
 edition = "2021"
 repository = "https://github.com/kkafar/master-monorepo.git"
 homepage = "https://github.com/kkafar/master-monorepo.git"

--- a/solver/src/cli.rs
+++ b/solver/src/cli.rs
@@ -1,8 +1,6 @@
 use clap::Parser;
 use std::path::PathBuf;
 
-use crate::VERSION;
-
 /// Jssp instance solver
 #[derive(Parser, Debug, Clone)]
 pub struct Args {

--- a/solver/src/cli.rs
+++ b/solver/src/cli.rs
@@ -1,6 +1,8 @@
 use clap::Parser;
 use std::path::PathBuf;
 
+use crate::VERSION;
+
 /// Jssp instance solver
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
@@ -53,6 +55,10 @@ pub struct Args {
     /// by solvers that do use "standard" JsspFitness.
     #[arg(long = "local-search-enabled")]
     pub local_search_enabled: Option<bool>,
+
+    /// Print solver version and exit.
+    #[arg(long = "version", default_value_t = false)]
+    pub version: bool,
 }
 
 fn validate_args(args: &Args) -> Result<(), String> {

--- a/solver/src/main.rs
+++ b/solver/src/main.rs
@@ -28,6 +28,12 @@ fn register_solvers(registry: &mut SolverRegistry) {
 
 fn run() -> anyhow::Result<()> {
     let args = cli::parse_args();
+
+    if args.version {
+        println!("{VERSION}");
+        return Ok(());
+    }
+
     let config = match Config::try_from(args) {
         Ok(config) => config,
         Err(err) => panic!("Failed to create config from args: {err}"),


### PR DESCRIPTION
- Allow for querying solver version
- Bump solver version
- Use python 3.11.3
- Dump solver & ecdk version into batch config file

## Description <!-- Please describe the motivation & changes introduced by this PR -->

## Linked issues <!-- Please use "Resolves #<issue_no> syntax in case this PR should be linked to an issue -->

Closes https://github.com/ecrs-org/ecrs/issues/486

## Important implementation details <!-- if any, optional section -->
